### PR TITLE
Add share specific resources in the skeleton, to ease adding the share.war in the same image, if desired.

### DIFF
--- a/4.2/skeleton/local/share-config-custom.xml
+++ b/4.2/skeleton/local/share-config-custom.xml
@@ -187,7 +187,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -334,7 +334,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -343,7 +343,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -352,7 +352,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>

--- a/4.2/skeleton/local/share-config-custom.xml
+++ b/4.2/skeleton/local/share-config-custom.xml
@@ -1,0 +1,445 @@
+<alfresco-config>
+
+   <!-- Global config section -->
+   <config replace="true">
+      <flags>
+         <!--
+            Developer debugging setting to turn on DEBUG mode for client scripts in the browser
+         -->
+         <client-debug>false</client-debug>
+
+         <!--
+            LOGGING can always be toggled at runtime when in DEBUG mode (Ctrl, Ctrl, Shift, Shift).
+            This flag automatically activates logging on page load.
+         -->
+         <client-debug-autologging>false</client-debug-autologging>
+      </flags>
+   </config>
+   
+   <config evaluator="string-compare" condition="WebFramework">
+      <web-framework>
+         <!-- SpringSurf Autowire Runtime Settings -->
+         <!-- 
+              Developers can set mode to 'development' to disable; SpringSurf caches,
+              FreeMarker template caching and Rhino JavaScript compilation.
+         -->
+         <autowire>
+            <!-- Pick the mode: "production" or "development" -->
+            <mode>production</mode>
+         </autowire>
+
+         <!-- Allows extension modules with <auto-deploy> set to true to be automatically deployed -->
+         <module-deployment>
+            <mode>manual</mode>
+            <enable-auto-deploy-modules>true</enable-auto-deploy-modules>
+         </module-deployment>
+      </web-framework>
+   </config>
+
+   <!-- Disable the CSRF Token Filter -->
+   <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      <filter/>
+   </config>
+
+   <!--
+      To run the CSRF Token Filter behind 1 or more proxies that do not rewrite the Origin or Referere headers:
+
+      1. Copy the "CSRFPolicy" default config in share-security-config.xml and paste it into this file.
+      2. Replace the old config by setting the <config> element's "replace" attribute to "true" like below:
+         <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      3. To every <action name="assertReferer"> element add the following child element
+         <param name="referer">http://www.proxy1.com/.*|http://www.proxy2.com/.*</param>
+      4. To every <action name="assertOrigin"> element add the following child element
+         <param name="origin">http://www.proxy1.com|http://www.proxy2.com</param>
+   -->
+
+   <!--
+      Remove the default wildcard setting and use instead a strict whitelist of the only domains that shall be allowed
+      to be used inside iframes (i.e. in the WebView dashlet on the dashboards)
+   -->
+   <!--
+   <config evaluator="string-compare" condition="IFramePolicy" replace="true">
+      <cross-domain>
+         <url>http://www.trusted-domain-1.com/</url>
+         <url>http://www.trusted-domain-2.com/</url>
+      </cross-domain>
+   </config>
+   -->
+
+   <!-- Turn off header that stops Share from being displayed in iframes on pages from other domains -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>X-Frame-Options</name>
+            <enabled>false</enabled>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <!-- Prevent browser communication over HTTP (for HTTPS servers) -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>Strict-Transport-Security</name>
+            <value>max-age=31536000</value>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Replication">
+      <share-urls>
+         <!--
+            To discover a Repository Id, browse to the remote server's CMIS landing page at:
+              http://{server}:{port}/alfresco/service/cmis/index.html
+            The Repository Id field is found under the "CMIS Repository Information" expandable panel.
+
+            Example config entry:
+              <share-url repositoryId="622f9533-2a1e-48fe-af4e-ee9e41667ea4">http://new-york-office:8080/share/</share-url>
+         -->
+      </share-urls>
+   </config>
+
+   <!-- Document Library config section -->
+   <config evaluator="string-compare" condition="DocumentLibrary" replace="true">
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>1000</maximum-folder-count>
+         
+         <!--  
+            Default timeout in milliseconds for folder Tree component to recieve response from Repository
+         -->
+         <timeout>7000</timeout>
+      </tree>
+
+      <!--
+         Used by the "Manage Aspects" action
+
+         For custom aspects, remember to also add the relevant i18n string(s)
+            cm_myaspect=My Aspect
+      -->
+      <aspects>
+         <!-- Aspects that a user can see -->
+         <visible>
+            <aspect name="cm:generalclassifiable" />
+            <aspect name="cm:complianceable" />
+            <aspect name="cm:dublincore" />
+            <aspect name="cm:effectivity" />
+            <aspect name="cm:summarizable" />
+            <aspect name="cm:versionable" />
+            <aspect name="cm:templatable" />
+            <aspect name="cm:emailed" />
+            <aspect name="emailserver:aliasable" />
+            <aspect name="cm:taggable" />
+            <aspect name="app:inlineeditable" />
+            <aspect name="cm:geographic" />
+            <aspect name="exif:exif" />
+            <aspect name="audio:audio" />
+            <aspect name="cm:indexControl" />
+            <aspect name="dp:restrictable" />
+         </visible>
+
+         <!-- Aspects that a user can add. Same as "visible" if left empty -->
+         <addable>
+         </addable>
+
+         <!-- Aspects that a user can remove. Same as "visible" if left empty -->
+         <removeable>
+         </removeable>
+      </aspects>
+
+      <!--
+         Used by the "Change Type" action
+
+         Define valid subtypes using the following example:
+            <type name="cm:content">
+               <subtype name="cm:mysubtype" />
+            </type>
+
+         Remember to also add the relevant i18n string(s):
+            cm_mysubtype=My SubType
+      -->
+      <types>
+         <type name="cm:content">
+         </type>
+
+         <type name="cm:folder">
+         </type>
+ 
+         <type name="trx:transferTarget">
+            <subtype name="trx:fileTransferTarget" />
+         </type>
+      </types>
+
+      <!--
+         If set, will present a WebDAV link for the current item on the Document and Folder details pages.
+         Also used to generate the "View in Alfresco Explorer" action for folders.
+      -->
+      <repository-url>http://localhost:8080/alfresco</repository-url>
+
+      <!--
+         Google Docs™ integration
+      -->
+      <google-docs>
+         <!--
+            Enable/disable the Google Docs UI integration (Extra types on Create Content menu, Google Docs actions).
+         -->
+         <enabled>false</enabled>
+
+         <!--
+            The mimetypes of documents Google Docs allows you to create via the Share interface.
+            The I18N label is created from the "type" attribute, e.g. google-docs.doc=Google Docs&trade; Document
+         -->
+         <creatable-types>
+            <creatable type="doc">application/vnd.openxmlformats-officedocument.wordprocessingml.document</creatable>
+            <creatable type="xls">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</creatable>
+            <creatable type="ppt">application/vnd.ms-powerpoint</creatable>
+         </creatable-types>
+      </google-docs>
+
+      <!--
+         File upload configuration
+      -->
+      <file-upload>
+         <!--
+            Adobe Flash™
+            In certain environments, an HTTP request originating from Flash cannot be authenticated using an existing session.
+            See: http://bugs.adobe.com/jira/browse/FP-4830
+            For these cases, it is useful to disable the Flash-based uploader for Share Document Libraries.
+         -->
+         <adobe-flash-enabled>true</adobe-flash-enabled>
+      </file-upload>
+   </config>
+
+
+   <!-- Custom DocLibActions config section -->
+   <config evaluator="string-compare" condition="DocLibActions">
+      <actionGroups>
+         <actionGroup id="document-browse">
+
+            <!-- Simple Repo Actions -->
+            <!--
+            <action index="340" id="document-extract-metadata" />
+            <action index="350" id="document-increment-counter" />
+            -->
+
+            <!-- Dialog Repo Actions -->
+            <!--
+            <action index="360" id="document-transform" />
+            <action index="370" id="document-transform-image" />
+            <action index="380" id="document-execute-script" />
+            -->
+
+         </actionGroup>
+      </actionGroups>
+   </config>
+
+   <!-- Global folder picker config section -->
+   <config evaluator="string-compare" condition="GlobalFolder">
+      <siteTree>
+         <container type="cm:folder">
+            <!-- Use a specific label for this container type in the tree -->
+            <rootLabel>location.path.documents</rootLabel>
+            <!-- Use a specific uri to retreive the child nodes for this container type in the tree -->
+            <uri>slingshot/doclib/treenode/site/{site}/{container}{path}?children={evaluateChildFoldersSite}&amp;max={maximumFolderCountSite}</uri>
+         </container>
+      </siteTree>
+   </config>
+
+   <!-- Repository Library config section -->
+   <config evaluator="string-compare" condition="RepositoryLibrary" replace="true">
+      <!--
+         Root nodeRef or xpath expression for top-level folder.
+         e.g. alfresco://user/home, /app:company_home/st:sites/cm:site1
+         If using an xpath expression, ensure it is properly ISO9075 encoded here.
+      -->
+      <root-node>alfresco://company/home</root-node>
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>500</maximum-folder-count>
+      </tree>
+
+      <!--
+         Whether the link to the Repository Library appears in the header component or not.
+      -->
+      <visible>true</visible>
+   </config>
+   
+   <!-- Kerberos settings -->
+   <!-- To enable kerberos rename this condition to "Kerberos" -->
+   <config evaluator="string-compare" condition="KerberosDisabled" replace="true">
+      <kerberos>
+         <!--
+            Password for HTTP service account.
+            The account name *must* be built from the HTTP server name, in the format :
+               HTTP/<server_name>@<realm>
+            (NB this is because the web browser requests an ST for the
+            HTTP/<server_name> principal in the current realm, so if we're to decode
+            that ST, it has to match.)
+         -->
+         <password>secret</password>
+         <!--
+            Kerberos realm and KDC address.
+         -->
+         <realm>ALFRESCO.ORG</realm>
+         <!--
+            Service Principal Name to use on the repository tier.
+            This must be like: HTTP/host.name@REALM
+         -->
+         <endpoint-spn>HTTP/repository.server.com@ALFRESCO.ORG</endpoint-spn>
+         <!--
+            JAAS login configuration entry name.
+         -->
+         <config-entry>ShareHTTP</config-entry>
+        <!--
+           A Boolean which when true strips the @domain sufix from Kerberos authenticated usernames.
+           Use together with stripUsernameSuffix property in alfresco-global.properties file.
+        -->
+        <stripUserNameSuffix>true</stripUserNameSuffix>
+      </kerberos>
+   </config>
+
+   <!-- Uncomment and modify the URL to Activiti Admin Console if required. -->
+   <!--
+   <config evaluator="string-compare" condition="ActivitiAdmin" replace="true">
+      <activiti-admin-url>http://localhost:8080/alfresco/activiti-admin</activiti-admin-url>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <endpoint>
+            <id>alfresco-noauth</id>
+            <name>Alfresco - unauthenticated access</name>
+            <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>none</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco-feed</id>
+            <name>Alfresco Feed</name>
+            <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
+            <connector-id>http</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <basic-auth>true</basic-auth>
+            <identity>user</identity>
+         </endpoint>
+         <!-- 
+         <endpoint>
+            <id>activiti-admin</id>
+            <name>Activiti Admin UI - user access</name>
+            <description>Access to Activiti Admin UI, that requires user authentication</description>
+            <connector-id>activiti-admin-connector</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/activiti-admin</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+         -->
+      </remote>
+   </config>
+
+   <!-- 
+        Overriding endpoints to reference an Alfresco server with external SSO enabled
+        NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky
+              sessions" feature of your load balancer must be used.
+        NOTE: If alfresco server location is not localhost:8080 then also combine changes from the
+              "example port config" section below.
+        *Optional* keystore contains SSL client certificate + trusted CAs.
+        Used to authenticate share to an external SSO system such as CAS
+        Remove the keystore section if not required i.e. for NTLM.
+        
+        NOTE: For Kerberos SSO rename the "KerberosDisabled" condition above to "Kerberos"
+        
+        NOTE: For external SSO, switch the endpoint connector to "AlfrescoHeader" and set
+              the userHeader to the name of the HTTP header that the external SSO
+              uses to provide the authenticated user name.
+   -->
+   <!--
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <keystore>
+             <path>alfresco/web-extension/alfresco-system.p12</path>
+             <type>pkcs12</type>
+             <password>alfresco-system</password>
+         </keystore>
+         
+         <connector>
+            <id>alfrescoCookie</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+         </connector>
+         
+         <connector>
+            <id>alfrescoHeader</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using header and cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+            <userHeader>SsoUserHeader</userHeader>
+         </connector>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfrescoCookie</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+      </remote>
+   </config>
+   -->
+
+   <!-- Cookie settings -->
+   <!-- To disable alfUsername2 cookie set enableCookie value to "false" -->
+   <!--
+   <plug-ins>
+      <element-readers>
+         <element-reader element-name="cookie" class="org.alfresco.web.config.cookie.CookieElementReader"/>
+      </element-readers>
+   </plug-ins>
+   
+   <config evaluator="string-compare" condition="Cookie" replace="true">
+      <cookie>
+         <enableCookie>false</enableCookie>
+         
+         <cookies-to-remove>
+            <cookie-to-remove>alfUsername3</cookie-to-remove>
+            <cookie-to-remove>alfLogin</cookie-to-remove>
+         </cookies-to-remove>
+      </cookie>
+   </config>
+   -->
+</alfresco-config>

--- a/5.0/skeleton/local/share-config-custom.xml
+++ b/5.0/skeleton/local/share-config-custom.xml
@@ -1,0 +1,489 @@
+<alfresco-config>
+
+   <!-- Global config section -->
+   <config replace="true">
+      <flags>
+         <!--
+            Developer debugging setting to turn on DEBUG mode for client scripts in the browser
+         -->
+         <client-debug>false</client-debug>
+
+         <!--
+            LOGGING can always be toggled at runtime when in DEBUG mode (Ctrl, Ctrl, Shift, Shift).
+            This flag automatically activates logging on page load.
+         -->
+         <client-debug-autologging>false</client-debug-autologging>
+      </flags>
+   </config>
+   
+   <config evaluator="string-compare" condition="WebFramework">
+      <web-framework>
+         <!-- SpringSurf Autowire Runtime Settings -->
+         <!-- 
+              Developers can set mode to 'development' to disable; SpringSurf caches,
+              FreeMarker template caching and Rhino JavaScript compilation.
+         -->
+         <autowire>
+            <!-- Pick the mode: "production" or "development" -->
+            <mode>production</mode>
+         </autowire>
+
+         <!-- Allows extension modules with <auto-deploy> set to true to be automatically deployed -->
+         <module-deployment>
+            <mode>manual</mode>
+            <enable-auto-deploy-modules>true</enable-auto-deploy-modules>
+         </module-deployment>
+      </web-framework>
+   </config>
+
+   <!-- Disable the CSRF Token Filter -->
+   <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      <filter/>
+   </config>
+
+   <!--
+      To run the CSRF Token Filter behind 1 or more proxies that do not rewrite the Origin or Referere headers:
+
+      1. Copy the "CSRFPolicy" default config in share-security-config.xml and paste it into this file.
+      2. Replace the old config by setting the <config> element's "replace" attribute to "true" like below:
+         <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      3. To every <action name="assertReferer"> element add the following child element
+         <param name="referer">http://www.proxy1.com/.*|http://www.proxy2.com/.*</param>
+      4. To every <action name="assertOrigin"> element add the following child element
+         <param name="origin">http://www.proxy1.com|http://www.proxy2.com</param>
+   -->
+
+   <!--
+      Remove the default wildcard setting and use instead a strict whitelist of the only domains that shall be allowed
+      to be used inside iframes (i.e. in the WebView dashlet on the dashboards)
+   -->
+   <!--
+   <config evaluator="string-compare" condition="IFramePolicy" replace="true">
+      <cross-domain>
+         <url>http://www.trusted-domain-1.com/</url>
+         <url>http://www.trusted-domain-2.com/</url>
+      </cross-domain>
+   </config>
+   -->
+
+   <!-- Turn off header that stops Share from being displayed in iframes on pages from other domains -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>X-Frame-Options</name>
+            <enabled>false</enabled>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <!-- Prevent browser communication over HTTP (for HTTPS servers) -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>Strict-Transport-Security</name>
+            <value>max-age=31536000</value>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Replication">
+      <share-urls>
+         <!--
+            To locate your current repositoryId go to Admin Console > General > Repository Information:
+              http://localhost:8080/alfresco/s/enterprise/admin/admin-repositoryinfo        
+
+            Example config entry:
+              <share-url repositoryId="622f9533-2a1e-48fe-af4e-ee9e41667ea4">http://new-york-office:8080/share/</share-url>
+         -->
+      </share-urls>
+   </config>
+
+   <!-- Document Library config section -->
+   <config evaluator="string-compare" condition="DocumentLibrary" replace="true">
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>1000</maximum-folder-count>
+         
+         <!--  
+            Default timeout in milliseconds for folder Tree component to recieve response from Repository
+         -->
+         <timeout>7000</timeout>
+      </tree>
+
+      <!--
+         Used by the "Manage Aspects" action
+
+         For custom aspects, remember to also add the relevant i18n string(s)
+            cm_myaspect=My Aspect
+      -->
+      <aspects>
+         <!-- Aspects that a user can see -->
+         <visible>
+            <aspect name="cm:generalclassifiable" />
+            <aspect name="cm:complianceable" />
+            <aspect name="cm:dublincore" />
+            <aspect name="cm:effectivity" />
+            <aspect name="cm:summarizable" />
+            <aspect name="cm:versionable" />
+            <aspect name="cm:templatable" />
+            <aspect name="cm:emailed" />
+            <aspect name="emailserver:aliasable" />
+            <aspect name="cm:taggable" />
+            <aspect name="app:inlineeditable" />
+            <aspect name="cm:geographic" />
+            <aspect name="exif:exif" />
+            <aspect name="audio:audio" />
+            <aspect name="cm:indexControl" />
+            <aspect name="dp:restrictable" />
+         </visible>
+
+         <!-- Aspects that a user can add. Same as "visible" if left empty -->
+         <addable>
+         </addable>
+
+         <!-- Aspects that a user can remove. Same as "visible" if left empty -->
+         <removeable>
+         </removeable>
+      </aspects>
+
+      <!--
+         Used by the "Change Type" action
+
+         Define valid subtypes using the following example:
+            <type name="cm:content">
+               <subtype name="cm:mysubtype" />
+            </type>
+
+         Remember to also add the relevant i18n string(s):
+            cm_mysubtype=My SubType
+      -->
+      <types>
+         <type name="cm:content">
+         </type>
+
+         <type name="cm:folder">
+         </type>
+ 
+         <type name="trx:transferTarget">
+            <subtype name="trx:fileTransferTarget" />
+         </type>
+      </types>
+
+      <!--
+         If set, will present a WebDAV link for the current item on the Document and Folder details pages.
+         Also used to generate the "View in Alfresco Explorer" action for folders.
+      -->
+      <repository-url>http://localhost:8080/alfresco</repository-url>
+
+      <!--
+         Google Docs™ integration
+      -->
+      <google-docs>
+         <!--
+            Enable/disable the Google Docs UI integration (Extra types on Create Content menu, Google Docs actions).
+         -->
+         <enabled>false</enabled>
+
+         <!--
+            The mimetypes of documents Google Docs allows you to create via the Share interface.
+            The I18N label is created from the "type" attribute, e.g. google-docs.doc=Google Docs&trade; Document
+         -->
+         <creatable-types>
+            <creatable type="doc">application/vnd.openxmlformats-officedocument.wordprocessingml.document</creatable>
+            <creatable type="xls">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</creatable>
+            <creatable type="ppt">application/vnd.ms-powerpoint</creatable>
+         </creatable-types>
+      </google-docs>
+
+      <!--
+         File upload configuration
+      -->
+      <file-upload>
+         <!--
+            Adobe Flash™
+            In certain environments, an HTTP request originating from Flash cannot be authenticated using an existing session.
+            See: http://bugs.adobe.com/jira/browse/FP-4830
+            For these cases, it is useful to disable the Flash-based uploader for Share Document Libraries.
+         -->
+         <adobe-flash-enabled>true</adobe-flash-enabled>
+      </file-upload>
+   </config>
+
+
+   <!-- Custom DocLibActions config section -->
+   <config evaluator="string-compare" condition="DocLibActions">
+      <actionGroups>
+         <actionGroup id="document-browse">
+
+            <!-- Simple Repo Actions -->
+            <!--
+            <action index="340" id="document-extract-metadata" />
+            <action index="350" id="document-increment-counter" />
+            -->
+
+            <!-- Dialog Repo Actions -->
+            <!--
+            <action index="360" id="document-transform" />
+            <action index="370" id="document-transform-image" />
+            <action index="380" id="document-execute-script" />
+            -->
+
+         </actionGroup>
+      </actionGroups>
+   </config>
+
+   <!-- Global folder picker config section -->
+   <config evaluator="string-compare" condition="GlobalFolder">
+      <siteTree>
+         <container type="cm:folder">
+            <!-- Use a specific label for this container type in the tree -->
+            <rootLabel>location.path.documents</rootLabel>
+            <!-- Use a specific uri to retreive the child nodes for this container type in the tree -->
+            <uri>slingshot/doclib/treenode/site/{site}/{container}{path}?children={evaluateChildFoldersSite}&amp;max={maximumFolderCountSite}</uri>
+         </container>
+      </siteTree>
+   </config>
+
+   <!-- Repository Library config section -->
+   <config evaluator="string-compare" condition="RepositoryLibrary" replace="true">
+      <!--
+         Root nodeRef or xpath expression for top-level folder.
+         e.g. alfresco://user/home, /app:company_home/st:sites/cm:site1
+         If using an xpath expression, ensure it is properly ISO9075 encoded here.
+      -->
+      <root-node>alfresco://company/home</root-node>
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>500</maximum-folder-count>
+      </tree>
+
+      <!--
+         Whether the link to the Repository Library appears in the header component or not.
+      -->
+      <visible>true</visible>
+   </config>
+   
+   <!-- Kerberos settings -->
+   <!-- To enable kerberos rename this condition to "Kerberos" -->
+   <config evaluator="string-compare" condition="KerberosDisabled" replace="true">
+      <kerberos>
+         <!--
+            Password for HTTP service account.
+            The account name *must* be built from the HTTP server name, in the format :
+               HTTP/<server_name>@<realm>
+            (NB this is because the web browser requests an ST for the
+            HTTP/<server_name> principal in the current realm, so if we're to decode
+            that ST, it has to match.)
+         -->
+         <password>secret</password>
+         <!--
+            Kerberos realm and KDC address.
+         -->
+         <realm>ALFRESCO.ORG</realm>
+         <!--
+            Service Principal Name to use on the repository tier.
+            This must be like: HTTP/host.name@REALM
+         -->
+         <endpoint-spn>HTTP/repository.server.com@ALFRESCO.ORG</endpoint-spn>
+         <!--
+            JAAS login configuration entry name.
+         -->
+         <config-entry>ShareHTTP</config-entry>
+        <!--
+           A Boolean which when true strips the @domain sufix from Kerberos authenticated usernames.
+           Use together with stripUsernameSuffix property in alfresco-global.properties file.
+        -->
+        <stripUserNameSuffix>true</stripUserNameSuffix>
+      </kerberos>
+   </config>
+
+   <!-- Uncomment and modify the URL to Activiti Admin Console if required. -->
+   <!--
+   <config evaluator="string-compare" condition="ActivitiAdmin" replace="true">
+      <activiti-admin-url>http://localhost:8080/alfresco/activiti-admin</activiti-admin-url>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <endpoint>
+            <id>alfresco-noauth</id>
+            <name>Alfresco - unauthenticated access</name>
+            <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>none</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco-feed</id>
+            <name>Alfresco Feed</name>
+            <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
+            <connector-id>http</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <basic-auth>true</basic-auth>
+            <identity>user</identity>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-api</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Public API - user access</name>
+            <description>Access to Alfresco Repository Public API that require user authentication.
+                         This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+      </remote>
+   </config>
+
+   <!-- 
+        Overriding endpoints to reference an Alfresco server with external SSO enabled
+        NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky
+              sessions" feature of your load balancer must be used.
+        NOTE: If alfresco server location is not localhost:8080 then also combine changes from the
+              "example port config" section below.
+        *Optional* ssl-config contains:
+              keystore for managing client key and certificate.
+              truststore for managing trusted CAs.
+        Used to authenticate share to an external SSO system such as CAS or 
+        to make share talk to SSL layers that require client certificates.
+        Remove the ssl-config section if not required i.e. for NTLM.
+        
+        NOTE: For Kerberos SSO rename the "KerberosDisabled" condition above to "Kerberos"
+        
+        NOTE: For external SSO, switch the endpoint connector to "alfrescoHeader" and set
+              the userHeader value to the name of the HTTP header that the external SSO
+              uses to provide the authenticated user name.
+        NOTE: For external SSO, Share now supports the "userIdPattern" mechanism as is available
+              on the repository config for External Authentication sub-system. Add the following
+              element to your "alfrescoHeader" connector config:
+              <userIdPattern>^ignore-(\w+)-ignore</userIdPattern>
+              This is an example, ensure the Id pattern matches your repository config.
+        NOTE: For external SSO, Share now supports stateless (no Http Session or sticky session)
+              connection to the repository when using the alfrescoHeader remote user connector.
+              e.g. You can change endpoint config to use the faster /service URL instead of the
+              /wcs URL if you are using External Authentication and then remove sticky session config
+              from your proxy between Share and Alfresco. Note that this is also faster because Share
+              will no longer call the /touch REST API before every remote call to the repository.
+   -->
+   <!-- Security warning -->
+   <!-- For production environment set verify-hostname to true.-->
+   <!--
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <ssl-config>
+            <keystore-path>alfresco/web-extension/alfresco-system.p12</keystore-path>
+            <keystore-type>pkcs12</keystore-type>
+            <keystore-password>alfresco-system</keystore-password>
+
+            <truststore-path>alfresco/web-extension/ssl-truststore</truststore-path>
+            <truststore-type>JCEKS</truststore-type>
+            <truststore-password>password</truststore-password>
+
+            <verify-hostname>true</verify-hostname>
+         </ssl-config>
+
+         <connector>
+            <id>alfrescoCookie</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+         </connector>
+         
+         <connector>
+            <id>alfrescoHeader</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using header and cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+            <userHeader>SsoUserHeader</userHeader>
+         </connector>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfrescoCookie</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-feed</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Feed</name>
+            <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description> 
+            <connector-id>alfrescoHeader</connector-id> 
+            <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-api</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Public API - user access</name>
+            <description>Access to Alfresco Repository Public API that require user authentication.
+                         This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
+            <connector-id>alfrescoHeader</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+      </remote>
+   </config>
+   -->
+
+   <!-- Cookie settings -->
+   <!-- To disable alfUsername2 cookie set enableCookie value to "false" -->
+   <!--
+   <plug-ins>
+      <element-readers>
+         <element-reader element-name="cookie" class="org.alfresco.web.config.cookie.CookieElementReader"/>
+      </element-readers>
+   </plug-ins>
+   
+   <config evaluator="string-compare" condition="Cookie" replace="true">
+      <cookie>
+         <enableCookie>false</enableCookie>
+         <cookies-to-remove>
+            <cookie-to-remove>alfUsername3</cookie-to-remove>
+            <cookie-to-remove>alfLogin</cookie-to-remove>
+         </cookies-to-remove>
+      </cookie>
+   </config>
+   -->
+</alfresco-config>

--- a/5.0/skeleton/local/share-config-custom.xml
+++ b/5.0/skeleton/local/share-config-custom.xml
@@ -186,7 +186,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -333,7 +333,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -342,7 +342,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -351,7 +351,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>
@@ -363,7 +363,7 @@
             <description>Access to Alfresco Repository Public API that require user authentication.
                          This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/api</endpoint-url>
             <identity>user</identity>
          </endpoint>
       </remote>

--- a/5.1/skeleton/local/share-config-custom.xml
+++ b/5.1/skeleton/local/share-config-custom.xml
@@ -187,7 +187,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -334,7 +334,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -343,7 +343,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -352,7 +352,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>

--- a/5.1/skeleton/local/share-config-custom.xml
+++ b/5.1/skeleton/local/share-config-custom.xml
@@ -1,0 +1,444 @@
+<alfresco-config>
+
+   <!-- Global config section -->
+   <config replace="true">
+      <flags>
+         <!--
+            Developer debugging setting to turn on DEBUG mode for client scripts in the browser
+         -->
+         <client-debug>false</client-debug>
+
+         <!--
+            LOGGING can always be toggled at runtime when in DEBUG mode (Ctrl, Ctrl, Shift, Shift).
+            This flag automatically activates logging on page load.
+         -->
+         <client-debug-autologging>false</client-debug-autologging>
+      </flags>
+   </config>
+   
+   <config evaluator="string-compare" condition="WebFramework">
+      <web-framework>
+         <!-- SpringSurf Autowire Runtime Settings -->
+         <!-- 
+              Developers can set mode to 'development' to disable; SpringSurf caches,
+              FreeMarker template caching and Rhino JavaScript compilation.
+         -->
+         <autowire>
+            <!-- Pick the mode: "production" or "development" -->
+            <mode>production</mode>
+         </autowire>
+
+         <!-- Allows extension modules with <auto-deploy> set to true to be automatically deployed -->
+         <module-deployment>
+            <mode>manual</mode>
+            <enable-auto-deploy-modules>true</enable-auto-deploy-modules>
+         </module-deployment>
+      </web-framework>
+   </config>
+
+   <!-- Disable the CSRF Token Filter -->
+   <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      <filter/>
+   </config>
+
+   <!--
+      To run the CSRF Token Filter behind 1 or more proxies that do not rewrite the Origin or Referere headers:
+
+      1. Copy the "CSRFPolicy" default config in share-security-config.xml and paste it into this file.
+      2. Replace the old config by setting the <config> element's "replace" attribute to "true" like below:
+         <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      3. To every <action name="assertReferer"> element add the following child element
+         <param name="referer">http://www.proxy1.com/.*|http://www.proxy2.com/.*</param>
+      4. To every <action name="assertOrigin"> element add the following child element
+         <param name="origin">http://www.proxy1.com|http://www.proxy2.com</param>
+   -->
+
+   <!--
+      Remove the default wildcard setting and use instead a strict whitelist of the only domains that shall be allowed
+      to be used inside iframes (i.e. in the WebView dashlet on the dashboards)
+   -->
+   <!--
+   <config evaluator="string-compare" condition="IFramePolicy" replace="true">
+      <cross-domain>
+         <url>http://www.trusted-domain-1.com/</url>
+         <url>http://www.trusted-domain-2.com/</url>
+      </cross-domain>
+   </config>
+   -->
+
+   <!-- Turn off header that stops Share from being displayed in iframes on pages from other domains -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>X-Frame-Options</name>
+            <enabled>false</enabled>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <!-- Prevent browser communication over HTTP (for HTTPS servers) -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>Strict-Transport-Security</name>
+            <value>max-age=31536000</value>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Replication">
+      <share-urls>
+         <!--
+            To discover a Repository Id, browse to the remote server's CMIS landing page at:
+              http://{server}:{port}/alfresco/service/cmis/index.html
+            The Repository Id field is found under the "CMIS Repository Information" expandable panel.
+
+            Example config entry:
+              <share-url repositoryId="622f9533-2a1e-48fe-af4e-ee9e41667ea4">http://new-york-office:8080/share/</share-url>
+         -->
+      </share-urls>
+   </config>
+
+   <!-- Document Library config section -->
+   <config evaluator="string-compare" condition="DocumentLibrary" replace="true">
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>1000</maximum-folder-count>
+         
+         <!--  
+            Default timeout in milliseconds for folder Tree component to recieve response from Repository
+         -->
+         <timeout>7000</timeout>
+      </tree>
+
+      <!--
+         Used by the "Manage Aspects" action
+
+         For custom aspects, remember to also add the relevant i18n string(s)
+            cm_myaspect=My Aspect
+      -->
+      <aspects>
+         <!-- Aspects that a user can see -->
+         <visible>
+            <aspect name="cm:generalclassifiable" />
+            <aspect name="cm:complianceable" />
+            <aspect name="cm:dublincore" />
+            <aspect name="cm:effectivity" />
+            <aspect name="cm:summarizable" />
+            <aspect name="cm:versionable" />
+            <aspect name="cm:templatable" />
+            <aspect name="cm:emailed" />
+            <aspect name="emailserver:aliasable" />
+            <aspect name="cm:taggable" />
+            <aspect name="app:inlineeditable" />
+            <aspect name="cm:geographic" />
+            <aspect name="exif:exif" />
+            <aspect name="audio:audio" />
+            <aspect name="cm:indexControl" />
+            <aspect name="dp:restrictable" />
+         </visible>
+
+         <!-- Aspects that a user can add. Same as "visible" if left empty -->
+         <addable>
+         </addable>
+
+         <!-- Aspects that a user can remove. Same as "visible" if left empty -->
+         <removeable>
+         </removeable>
+      </aspects>
+
+      <!--
+         Used by the "Change Type" action
+
+         Define valid subtypes using the following example:
+            <type name="cm:content">
+               <subtype name="cm:mysubtype" />
+            </type>
+
+         Remember to also add the relevant i18n string(s):
+            cm_mysubtype=My SubType
+      -->
+      <types>
+         <type name="cm:content">
+         </type>
+
+         <type name="cm:folder">
+         </type>
+ 
+         <type name="trx:transferTarget">
+            <subtype name="trx:fileTransferTarget" />
+         </type>
+      </types>
+
+      <!--
+         If set, will present a WebDAV link for the current item on the Document and Folder details pages.
+         Also used to generate the "View in Alfresco Explorer" action for folders.
+      -->
+      <repository-url>http://localhost:8080/alfresco</repository-url>
+
+      <!--
+         Google Docs™ integration
+      -->
+      <google-docs>
+         <!--
+            Enable/disable the Google Docs UI integration (Extra types on Create Content menu, Google Docs actions).
+         -->
+         <enabled>false</enabled>
+
+         <!--
+            The mimetypes of documents Google Docs allows you to create via the Share interface.
+            The I18N label is created from the "type" attribute, e.g. google-docs.doc=Google Docs&trade; Document
+         -->
+         <creatable-types>
+            <creatable type="doc">application/vnd.openxmlformats-officedocument.wordprocessingml.document</creatable>
+            <creatable type="xls">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</creatable>
+            <creatable type="ppt">application/vnd.ms-powerpoint</creatable>
+         </creatable-types>
+      </google-docs>
+
+      <!--
+         File upload configuration
+      -->
+      <file-upload>
+         <!--
+            Adobe Flash™
+            In certain environments, an HTTP request originating from Flash cannot be authenticated using an existing session.
+            See: http://bugs.adobe.com/jira/browse/FP-4830
+            For these cases, it is useful to disable the Flash-based uploader for Share Document Libraries.
+         -->
+         <adobe-flash-enabled>true</adobe-flash-enabled>
+      </file-upload>
+   </config>
+
+
+   <!-- Custom DocLibActions config section -->
+   <config evaluator="string-compare" condition="DocLibActions">
+      <actionGroups>
+         <actionGroup id="document-browse">
+
+            <!-- Simple Repo Actions -->
+            <!--
+            <action index="340" id="document-extract-metadata" />
+            <action index="350" id="document-increment-counter" />
+            -->
+
+            <!-- Dialog Repo Actions -->
+            <!--
+            <action index="360" id="document-transform" />
+            <action index="370" id="document-transform-image" />
+            <action index="380" id="document-execute-script" />
+            -->
+
+         </actionGroup>
+      </actionGroups>
+   </config>
+
+   <!-- Global folder picker config section -->
+   <config evaluator="string-compare" condition="GlobalFolder">
+      <siteTree>
+         <container type="cm:folder">
+            <!-- Use a specific label for this container type in the tree -->
+            <rootLabel>location.path.documents</rootLabel>
+            <!-- Use a specific uri to retreive the child nodes for this container type in the tree -->
+            <uri>slingshot/doclib/treenode/site/{site}/{container}{path}?children={evaluateChildFoldersSite}&amp;max={maximumFolderCountSite}</uri>
+         </container>
+      </siteTree>
+   </config>
+
+   <!-- Repository Library config section -->
+   <config evaluator="string-compare" condition="RepositoryLibrary" replace="true">
+      <!--
+         Root nodeRef or xpath expression for top-level folder.
+         e.g. alfresco://user/home, /app:company_home/st:sites/cm:site1
+         If using an xpath expression, ensure it is properly ISO9075 encoded here.
+      -->
+      <root-node>alfresco://company/home</root-node>
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>500</maximum-folder-count>
+      </tree>
+
+      <!--
+         Whether the link to the Repository Library appears in the header component or not.
+      -->
+      <visible>true</visible>
+   </config>
+   
+   <!-- Kerberos settings -->
+   <!-- To enable kerberos rename this condition to "Kerberos" -->
+   <config evaluator="string-compare" condition="KerberosDisabled" replace="true">
+      <kerberos>
+         <!--
+            Password for HTTP service account.
+            The account name *must* be built from the HTTP server name, in the format :
+               HTTP/<server_name>@<realm>
+            (NB this is because the web browser requests an ST for the
+            HTTP/<server_name> principal in the current realm, so if we're to decode
+            that ST, it has to match.)
+         -->
+         <password>secret</password>
+         <!--
+            Kerberos realm and KDC address.
+         -->
+         <realm>ALFRESCO.ORG</realm>
+         <!--
+            Service Principal Name to use on the repository tier.
+            This must be like: HTTP/host.name@REALM
+         -->
+         <endpoint-spn>HTTP/repository.server.com@ALFRESCO.ORG</endpoint-spn>
+         <!--
+            JAAS login configuration entry name.
+         -->
+         <config-entry>ShareHTTP</config-entry>
+        <!--
+           A Boolean which when true strips the @domain sufix from Kerberos authenticated usernames.
+           Use together with stripUsernameSuffix property in alfresco-global.properties file.
+        -->
+        <stripUserNameSuffix>true</stripUserNameSuffix>
+      </kerberos>
+   </config>
+
+   <!-- Uncomment and modify the URL to Activiti Admin Console if required. -->
+   <!--
+   <config evaluator="string-compare" condition="ActivitiAdmin" replace="true">
+      <activiti-admin-url>http://localhost:8080/alfresco/activiti-admin</activiti-admin-url>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <endpoint>
+            <id>alfresco-noauth</id>
+            <name>Alfresco - unauthenticated access</name>
+            <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>none</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco-feed</id>
+            <name>Alfresco Feed</name>
+            <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
+            <connector-id>http</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <basic-auth>true</basic-auth>
+            <identity>user</identity>
+         </endpoint>
+         <!-- 
+         <endpoint>
+            <id>activiti-admin</id>
+            <name>Activiti Admin UI - user access</name>
+            <description>Access to Activiti Admin UI, that requires user authentication</description>
+            <connector-id>activiti-admin-connector</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/activiti-admin</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+         -->
+      </remote>
+   </config>
+
+   <!-- 
+        Overriding endpoints to reference an Alfresco server with external SSO enabled
+        NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky
+              sessions" feature of your load balancer must be used.
+        NOTE: If alfresco server location is not localhost:8080 then also combine changes from the
+              "example port config" section below.
+        *Optional* keystore contains SSL client certificate + trusted CAs.
+        Used to authenticate share to an external SSO system such as CAS
+        Remove the keystore section if not required i.e. for NTLM.
+        
+        NOTE: For Kerberos SSO rename the "KerberosDisabled" condition above to "Kerberos"
+        
+        NOTE: For external SSO, switch the endpoint connector to "AlfrescoHeader" and set
+              the userHeader to the name of the HTTP header that the external SSO
+              uses to provide the authenticated user name.
+   -->
+   <!--
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <keystore>
+             <path>alfresco/web-extension/alfresco-system.p12</path>
+             <type>pkcs12</type>
+             <password>alfresco-system</password>
+         </keystore>
+         
+         <connector>
+            <id>alfrescoCookie</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+         </connector>
+         
+         <connector>
+            <id>alfrescoHeader</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using header and cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+            <userHeader>SsoUserHeader</userHeader>
+         </connector>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfrescoCookie</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+      </remote>
+   </config>
+   -->
+
+   <!-- Cookie settings -->
+   <!-- To disable alfUsername2 cookie set enableCookie value to "false" -->
+   <!--
+   <plug-ins>
+      <element-readers>
+         <element-reader element-name="cookie" class="org.alfresco.web.config.cookie.CookieElementReader"/>
+      </element-readers>
+   </plug-ins>
+   
+   <config evaluator="string-compare" condition="Cookie" replace="true">
+      <cookie>
+         <enableCookie>false</enableCookie>
+         <cookies-to-remove>
+            <cookie-to-remove>alfUsername3</cookie-to-remove>
+            <cookie-to-remove>alfLogin</cookie-to-remove>
+         </cookies-to-remove>
+      </cookie>
+   </config>
+   -->
+</alfresco-config>

--- a/5.2/skeleton/local/share-config-custom.xml
+++ b/5.2/skeleton/local/share-config-custom.xml
@@ -1,0 +1,514 @@
+<alfresco-config>
+
+   <!-- Global config section -->
+   <config replace="true">
+      <flags>
+         <!--
+            Developer debugging setting to turn on DEBUG mode for client scripts in the browser
+         -->
+         <client-debug>false</client-debug>
+
+         <!--
+            LOGGING can always be toggled at runtime when in DEBUG mode (Ctrl, Ctrl, Shift, Shift).
+            This flag automatically activates logging on page load.
+         -->
+         <client-debug-autologging>false</client-debug-autologging>
+      </flags>
+   </config>
+   
+   <config evaluator="string-compare" condition="WebFramework">
+      <web-framework>
+         <!-- SpringSurf Autowire Runtime Settings -->
+         <!-- 
+              Developers can set mode to 'development' to disable; SpringSurf caches,
+              FreeMarker template caching and Rhino JavaScript compilation.
+         -->
+         <autowire>
+            <!-- Pick the mode: "production" or "development" -->
+            <mode>production</mode>
+         </autowire>
+
+         <!-- Allows extension modules with <auto-deploy> set to true to be automatically deployed -->
+         <module-deployment>
+            <mode>manual</mode>
+            <enable-auto-deploy-modules>true</enable-auto-deploy-modules>
+         </module-deployment>
+      </web-framework>
+   </config>
+
+   <!-- Disable the CSRF Token Filter -->
+   <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      <filter/>
+   </config>
+
+   <!--
+      To run the CSRF Token Filter behind 1 or more proxies that do not rewrite the Origin or Referere headers:
+
+      1. Copy the "CSRFPolicy" default config in share-security-config.xml and paste it into this file.
+      2. Replace the old config by setting the <config> element's "replace" attribute to "true" like below:
+         <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      3. To every <action name="assertReferer"> element add the following child element
+         <param name="referer">http://www.proxy1.com/.*|http://www.proxy2.com/.*</param>
+      4. To every <action name="assertOrigin"> element add the following child element
+         <param name="origin">http://www.proxy1.com|http://www.proxy2.com</param>
+   -->
+
+   <!--
+      Remove the default wildcard setting and use instead a strict whitelist of the only domains that shall be allowed
+      to be used inside iframes (i.e. in the WebView dashlet on the dashboards)
+   -->
+   <!--
+   <config evaluator="string-compare" condition="IFramePolicy" replace="true">
+      <cross-domain>
+         <url>http://www.trusted-domain-1.com/</url>
+         <url>http://www.trusted-domain-2.com/</url>
+      </cross-domain>
+   </config>
+   -->
+
+   <!-- Turn off header that stops Share from being displayed in iframes on pages from other domains -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>X-Frame-Options</name>
+            <enabled>false</enabled>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <!-- Prevent browser communication over HTTP (for HTTPS servers) -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>Strict-Transport-Security</name>
+            <value>max-age=31536000</value>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Replication">
+      <share-urls>
+         <!--
+            To locate your current repositoryId go to Admin Console > General > Repository Information:
+              http://localhost:8080/alfresco/s/enterprise/admin/admin-repositoryinfo        
+
+            Example config entry:
+              <share-url repositoryId="622f9533-2a1e-48fe-af4e-ee9e41667ea4">http://new-york-office:8080/share/</share-url>
+         -->
+      </share-urls>
+   </config>
+
+   <!-- Document Library config section -->
+   <config evaluator="string-compare" condition="DocumentLibrary" replace="true">
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>1000</maximum-folder-count>
+         
+         <!--  
+            Default timeout in milliseconds for folder Tree component to recieve response from Repository
+         -->
+         <timeout>7000</timeout>
+      </tree>
+
+      <!--
+         Used by "Manage Rules" -> "Add aspect" action.
+
+         If an aspect has been specified without a title element in the content model,
+         or you need to support multiple languages,
+         then an i18n file is needed on the Repo AMP/JAR extension side for the aspect to
+         be visible when creating rules:
+
+          custom_customModel.aspect.custom_myaspect.title=My Aspect
+
+         Used by the "Manage Aspects" action.
+
+         For the aspect to have a localised label add relevant i18n string(s) in a Share AMP/JAR extension:
+
+          aspect.custom_myaspect=My Aspect
+      -->
+      <aspects>
+         <!-- Aspects that a user can see -->
+         <visible>
+            <aspect name="cm:generalclassifiable" />
+            <aspect name="cm:complianceable" />
+            <aspect name="cm:dublincore" />
+            <aspect name="cm:effectivity" />
+            <aspect name="cm:summarizable" />
+            <aspect name="cm:versionable" />
+            <aspect name="cm:templatable" />
+            <aspect name="cm:emailed" />
+            <aspect name="emailserver:aliasable" />
+            <aspect name="cm:taggable" />
+            <aspect name="app:inlineeditable" />
+            <aspect name="cm:geographic" />
+            <aspect name="exif:exif" />
+            <aspect name="audio:audio" />
+            <aspect name="cm:indexControl" />
+            <aspect name="dp:restrictable" />
+            <aspect name="smf:customConfigSmartFolder" />
+            <aspect name="smf:systemConfigSmartFolder" />
+         </visible>
+
+         <!-- Aspects that a user can add. Same as "visible" if left empty -->
+         <addable>
+         </addable>
+
+         <!-- Aspects that a user can remove. Same as "visible" if left empty -->
+         <removeable>
+         </removeable>
+      </aspects>
+
+      <!--
+         Used by "Manage Rules" -> "Specialise type" action.
+
+         If a type has been specified without a title element in the content model,
+         or you need to support multiple languages,
+         then an i18n file is needed on the Repo AMP/JAR extension side for the type to
+         be visible when creating rules:
+
+            custom_customModel.type.custom_mytype.title=My SubType
+
+         Used by the "Change Type" action.
+
+         For the type to have a localised label add relevant i18n string(s) in a Share AMP/JAR extension:
+
+            type.custom_mytype=My SubType
+
+         Define valid subtypes using the following example:
+
+            <type name="cm:content">
+             <subtype name="custom:mytype" />
+            </type>
+      -->
+      <types>
+         <type name="cm:content">
+            <subtype name="smf:smartFolderTemplate" />
+         </type>
+
+          <type name="cm:folder">
+         </type>
+
+         <type name="trx:transferTarget">
+            <subtype name="trx:fileTransferTarget" />
+         </type>
+      </types>
+
+      <!--
+         If set, will present a WebDAV link for the current item on the Document and Folder details pages.
+         Also used to generate the "View in Alfresco Explorer" action for folders.
+      -->
+      <repository-url>http://localhost:8080/alfresco</repository-url>
+
+      <!--
+         Google Docs™ integration
+      -->
+      <google-docs>
+         <!--
+            Enable/disable the Google Docs UI integration (Extra types on Create Content menu, Google Docs actions).
+         -->
+         <enabled>false</enabled>
+
+         <!--
+            The mimetypes of documents Google Docs allows you to create via the Share interface.
+            The I18N label is created from the "type" attribute, e.g. google-docs.doc=Google Docs&trade; Document
+         -->
+         <creatable-types>
+            <creatable type="doc">application/vnd.openxmlformats-officedocument.wordprocessingml.document</creatable>
+            <creatable type="xls">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</creatable>
+            <creatable type="ppt">application/vnd.ms-powerpoint</creatable>
+         </creatable-types>
+      </google-docs>
+
+      <!--
+         File upload configuration
+      -->
+      <file-upload>
+         <!--
+            Adobe Flash™
+            In certain environments, an HTTP request originating from Flash cannot be authenticated using an existing session.
+            See: http://bugs.adobe.com/jira/browse/FP-4830
+            For these cases, it is useful to disable the Flash-based uploader for Share Document Libraries.
+         -->
+         <adobe-flash-enabled>true</adobe-flash-enabled>
+      </file-upload>
+   </config>
+
+
+   <!-- Custom DocLibActions config section -->
+   <config evaluator="string-compare" condition="DocLibActions">
+      <actionGroups>
+         <actionGroup id="document-browse">
+
+            <!-- Simple Repo Actions -->
+            <!--
+            <action index="340" id="document-extract-metadata" />
+            <action index="350" id="document-increment-counter" />
+            -->
+
+            <!-- Dialog Repo Actions -->
+            <!--
+            <action index="360" id="document-transform" />
+            <action index="370" id="document-transform-image" />
+            <action index="380" id="document-execute-script" />
+            -->
+
+         </actionGroup>
+      </actionGroups>
+   </config>
+
+   <!-- Global folder picker config section -->
+   <config evaluator="string-compare" condition="GlobalFolder">
+      <siteTree>
+         <container type="cm:folder">
+            <!-- Use a specific label for this container type in the tree -->
+            <rootLabel>location.path.documents</rootLabel>
+            <!-- Use a specific uri to retreive the child nodes for this container type in the tree -->
+            <uri>slingshot/doclib/treenode/site/{site}/{container}{path}?children={evaluateChildFoldersSite}&amp;max={maximumFolderCountSite}</uri>
+         </container>
+      </siteTree>
+   </config>
+
+   <!-- Repository Library config section -->
+   <config evaluator="string-compare" condition="RepositoryLibrary" replace="true">
+      <!--
+         Root nodeRef or xpath expression for top-level folder.
+         e.g. alfresco://user/home, /app:company_home/st:sites/cm:site1
+         If using an xpath expression, ensure it is properly ISO9075 encoded here.
+      -->
+      <root-node>alfresco://company/home</root-node>
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>500</maximum-folder-count>
+      </tree>
+
+      <!--
+         Whether the link to the Repository Library appears in the header component or not.
+      -->
+      <visible>true</visible>
+   </config>
+   
+   <!-- Kerberos settings -->
+   <!-- To enable kerberos rename this condition to "Kerberos" -->
+   <config evaluator="string-compare" condition="KerberosDisabled" replace="true">
+      <kerberos>
+         <!--
+            Password for HTTP service account.
+            The account name *must* be built from the HTTP server name, in the format :
+               HTTP/<server_name>@<realm>
+            (NB this is because the web browser requests an ST for the
+            HTTP/<server_name> principal in the current realm, so if we're to decode
+            that ST, it has to match.)
+         -->
+         <password>secret</password>
+         <!--
+            Kerberos realm and KDC address.
+         -->
+         <realm>ALFRESCO.ORG</realm>
+         <!--
+            Service Principal Name to use on the repository tier.
+            This must be like: HTTP/host.name@REALM
+         -->
+         <endpoint-spn>HTTP/repository.server.com@ALFRESCO.ORG</endpoint-spn>
+         <!--
+            JAAS login configuration entry name.
+         -->
+         <config-entry>ShareHTTP</config-entry>
+        <!--
+           A Boolean which when true strips the @domain sufix from Kerberos authenticated usernames.
+           Use together with stripUsernameSuffix property in alfresco-global.properties file.
+        -->
+        <stripUserNameSuffix>true</stripUserNameSuffix>
+      </kerberos>
+   </config>
+
+   <!-- Uncomment and modify the URL to Activiti Admin Console if required. -->
+   <!--
+   <config evaluator="string-compare" condition="ActivitiAdmin" replace="true">
+      <activiti-admin-url>http://localhost:8080/alfresco/activiti-admin</activiti-admin-url>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <endpoint>
+            <id>alfresco-noauth</id>
+            <name>Alfresco - unauthenticated access</name>
+            <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>none</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco-feed</id>
+            <name>Alfresco Feed</name>
+            <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
+            <connector-id>http</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <basic-auth>true</basic-auth>
+            <identity>user</identity>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-api</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Public API - user access</name>
+            <description>Access to Alfresco Repository Public API that require user authentication.
+                         This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+      </remote>
+   </config>
+
+   <!-- 
+        Overriding endpoints to reference an Alfresco server with external SSO enabled
+        NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky
+              sessions" feature of your load balancer must be used.
+        NOTE: If alfresco server location is not localhost:8080 then also combine changes from the
+              "example port config" section below.
+        *Optional* ssl-config contains:
+              keystore for managing client key and certificate.
+              truststore for managing trusted CAs.
+        Used to authenticate share to an external SSO system such as CAS or 
+        to make share talk to SSL layers that require client certificates.
+        Remove the ssl-config section if not required i.e. for NTLM.
+        
+        NOTE: For Kerberos SSO rename the "KerberosDisabled" condition above to "Kerberos"
+        
+        NOTE: For external SSO, switch the endpoint connector to "alfrescoHeader" and set
+              the userHeader value to the name of the HTTP header that the external SSO
+              uses to provide the authenticated user name.
+        NOTE: For external SSO, Share now supports the "userIdPattern" mechanism as is available
+              on the repository config for External Authentication sub-system. Add the following
+              element to your "alfrescoHeader" connector config:
+              <userIdPattern>^ignore-(\w+)-ignore</userIdPattern>
+              This is an example, ensure the Id pattern matches your repository config.
+        NOTE: For external SSO, Share now supports stateless (no Http Session or sticky session)
+              connection to the repository when using the alfrescoHeader remote user connector.
+              e.g. You can change endpoint config to use the faster /service URL instead of the
+              /wcs URL if you are using External Authentication and then remove sticky session config
+              from your proxy between Share and Alfresco. Note that this is also faster because Share
+              will no longer call the /touch REST API before every remote call to the repository.
+   -->
+
+   <!-- Security warning -->
+   <!-- For production environment set verify-hostname to true.-->
+   <!--
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <ssl-config>
+            <keystore-path>alfresco/web-extension/alfresco-system.p12</keystore-path>
+            <keystore-type>pkcs12</keystore-type>
+            <keystore-password>alfresco-system</keystore-password>
+
+            <truststore-path>alfresco/web-extension/ssl-truststore</truststore-path>
+            <truststore-type>JCEKS</truststore-type>
+            <truststore-password>password</truststore-password>
+
+            <verify-hostname>true</verify-hostname>
+         </ssl-config>
+
+         <connector>
+            <id>alfrescoCookie</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+         </connector>
+         
+         <connector>
+            <id>alfrescoHeader</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using header and cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+            <userHeader>SsoUserHeader</userHeader>
+         </connector>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfrescoCookie</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-feed</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Feed</name>
+            <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description> 
+            <connector-id>alfrescoHeader</connector-id> 
+            <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-api</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Public API - user access</name>
+            <description>Access to Alfresco Repository Public API that require user authentication.
+                         This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
+            <connector-id>alfrescoHeader</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+      </remote>
+   </config>
+   -->
+
+   <!-- Cookie settings -->
+   <!-- To disable alfUsername2 cookie set enableCookie value to "false" -->
+   <!--
+   <plug-ins>
+      <element-readers>
+         <element-reader element-name="cookie" class="org.alfresco.web.config.cookie.CookieElementReader"/>
+      </element-readers>
+   </plug-ins>
+   
+   <config evaluator="string-compare" condition="Cookie" replace="true">
+      <cookie>
+         <enableCookie>false</enableCookie>
+         <cookies-to-remove>
+            <cookie-to-remove>alfUsername3</cookie-to-remove>
+            <cookie-to-remove>alfLogin</cookie-to-remove>
+         </cookies-to-remove>
+      </cookie>
+   </config>
+   -->
+</alfresco-config>

--- a/5.2/skeleton/local/share-config-custom.xml
+++ b/5.2/skeleton/local/share-config-custom.xml
@@ -210,7 +210,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -357,7 +357,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -366,7 +366,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -375,7 +375,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>
@@ -387,7 +387,7 @@
             <description>Access to Alfresco Repository Public API that require user authentication.
                          This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/api</endpoint-url>
             <identity>user</identity>
          </endpoint>
       </remote>

--- a/6.0/skeleton/local/share-config-custom.xml
+++ b/6.0/skeleton/local/share-config-custom.xml
@@ -1,0 +1,514 @@
+<alfresco-config>
+
+   <!-- Global config section -->
+   <config replace="true">
+      <flags>
+         <!--
+            Developer debugging setting to turn on DEBUG mode for client scripts in the browser
+         -->
+         <client-debug>false</client-debug>
+
+         <!--
+            LOGGING can always be toggled at runtime when in DEBUG mode (Ctrl, Ctrl, Shift, Shift).
+            This flag automatically activates logging on page load.
+         -->
+         <client-debug-autologging>false</client-debug-autologging>
+      </flags>
+   </config>
+   
+   <config evaluator="string-compare" condition="WebFramework">
+      <web-framework>
+         <!-- SpringSurf Autowire Runtime Settings -->
+         <!-- 
+              Developers can set mode to 'development' to disable; SpringSurf caches,
+              FreeMarker template caching and Rhino JavaScript compilation.
+         -->
+         <autowire>
+            <!-- Pick the mode: "production" or "development" -->
+            <mode>production</mode>
+         </autowire>
+
+         <!-- Allows extension modules with <auto-deploy> set to true to be automatically deployed -->
+         <module-deployment>
+            <mode>manual</mode>
+            <enable-auto-deploy-modules>true</enable-auto-deploy-modules>
+         </module-deployment>
+      </web-framework>
+   </config>
+
+   <!-- Disable the CSRF Token Filter -->
+   <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      <filter/>
+   </config>
+
+   <!--
+      To run the CSRF Token Filter behind 1 or more proxies that do not rewrite the Origin or Referere headers:
+
+      1. Copy the "CSRFPolicy" default config in share-security-config.xml and paste it into this file.
+      2. Replace the old config by setting the <config> element's "replace" attribute to "true" like below:
+         <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      3. To every <action name="assertReferer"> element add the following child element
+         <param name="referer">http://www.proxy1.com/.*|http://www.proxy2.com/.*</param>
+      4. To every <action name="assertOrigin"> element add the following child element
+         <param name="origin">http://www.proxy1.com|http://www.proxy2.com</param>
+   -->
+
+   <!--
+      Remove the default wildcard setting and use instead a strict whitelist of the only domains that shall be allowed
+      to be used inside iframes (i.e. in the WebView dashlet on the dashboards)
+   -->
+   <!--
+   <config evaluator="string-compare" condition="IFramePolicy" replace="true">
+      <cross-domain>
+         <url>http://www.trusted-domain-1.com/</url>
+         <url>http://www.trusted-domain-2.com/</url>
+      </cross-domain>
+   </config>
+   -->
+
+   <!-- Turn off header that stops Share from being displayed in iframes on pages from other domains -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>X-Frame-Options</name>
+            <enabled>false</enabled>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <!-- Prevent browser communication over HTTP (for HTTPS servers) -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>Strict-Transport-Security</name>
+            <value>max-age=31536000</value>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Replication">
+      <share-urls>
+         <!--
+            To locate your current repositoryId go to Admin Console > General > Repository Information:
+              http://localhost:8080/alfresco/s/enterprise/admin/admin-repositoryinfo        
+
+            Example config entry:
+              <share-url repositoryId="622f9533-2a1e-48fe-af4e-ee9e41667ea4">http://new-york-office:8080/share/</share-url>
+         -->
+      </share-urls>
+   </config>
+
+   <!-- Document Library config section -->
+   <config evaluator="string-compare" condition="DocumentLibrary" replace="true">
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>1000</maximum-folder-count>
+         
+         <!--  
+            Default timeout in milliseconds for folder Tree component to recieve response from Repository
+         -->
+         <timeout>7000</timeout>
+      </tree>
+
+      <!--
+         Used by "Manage Rules" -> "Add aspect" action.
+
+         If an aspect has been specified without a title element in the content model,
+         or you need to support multiple languages,
+         then an i18n file is needed on the Repo AMP/JAR extension side for the aspect to
+         be visible when creating rules:
+
+          custom_customModel.aspect.custom_myaspect.title=My Aspect
+
+         Used by the "Manage Aspects" action.
+
+         For the aspect to have a localised label add relevant i18n string(s) in a Share AMP/JAR extension:
+
+          aspect.custom_myaspect=My Aspect
+      -->
+      <aspects>
+         <!-- Aspects that a user can see -->
+         <visible>
+            <aspect name="cm:generalclassifiable" />
+            <aspect name="cm:complianceable" />
+            <aspect name="cm:dublincore" />
+            <aspect name="cm:effectivity" />
+            <aspect name="cm:summarizable" />
+            <aspect name="cm:versionable" />
+            <aspect name="cm:templatable" />
+            <aspect name="cm:emailed" />
+            <aspect name="emailserver:aliasable" />
+            <aspect name="cm:taggable" />
+            <aspect name="app:inlineeditable" />
+            <aspect name="cm:geographic" />
+            <aspect name="exif:exif" />
+            <aspect name="audio:audio" />
+            <aspect name="cm:indexControl" />
+            <aspect name="dp:restrictable" />
+            <aspect name="smf:customConfigSmartFolder" />
+            <aspect name="smf:systemConfigSmartFolder" />
+         </visible>
+
+         <!-- Aspects that a user can add. Same as "visible" if left empty -->
+         <addable>
+         </addable>
+
+         <!-- Aspects that a user can remove. Same as "visible" if left empty -->
+         <removeable>
+         </removeable>
+      </aspects>
+
+      <!--
+         Used by "Manage Rules" -> "Specialise type" action.
+
+         If a type has been specified without a title element in the content model,
+         or you need to support multiple languages,
+         then an i18n file is needed on the Repo AMP/JAR extension side for the type to
+         be visible when creating rules:
+
+            custom_customModel.type.custom_mytype.title=My SubType
+
+         Used by the "Change Type" action.
+
+         For the type to have a localised label add relevant i18n string(s) in a Share AMP/JAR extension:
+
+            type.custom_mytype=My SubType
+
+         Define valid subtypes using the following example:
+
+            <type name="cm:content">
+             <subtype name="custom:mytype" />
+            </type>
+      -->
+      <types>
+         <type name="cm:content">
+            <subtype name="smf:smartFolderTemplate" />
+         </type>
+
+          <type name="cm:folder">
+         </type>
+
+         <type name="trx:transferTarget">
+            <subtype name="trx:fileTransferTarget" />
+         </type>
+      </types>
+
+      <!--
+         If set, will present a WebDAV link for the current item on the Document and Folder details pages.
+         Also used to generate the "View in Alfresco Explorer" action for folders.
+      -->
+      <repository-url>http://localhost:8080/alfresco</repository-url>
+
+      <!--
+         Google Docs™ integration
+      -->
+      <google-docs>
+         <!--
+            Enable/disable the Google Docs UI integration (Extra types on Create Content menu, Google Docs actions).
+         -->
+         <enabled>false</enabled>
+
+         <!--
+            The mimetypes of documents Google Docs allows you to create via the Share interface.
+            The I18N label is created from the "type" attribute, e.g. google-docs.doc=Google Docs&trade; Document
+         -->
+         <creatable-types>
+            <creatable type="doc">application/vnd.openxmlformats-officedocument.wordprocessingml.document</creatable>
+            <creatable type="xls">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</creatable>
+            <creatable type="ppt">application/vnd.ms-powerpoint</creatable>
+         </creatable-types>
+      </google-docs>
+
+      <!--
+         File upload configuration
+      -->
+      <file-upload>
+         <!--
+            Adobe Flash™
+            In certain environments, an HTTP request originating from Flash cannot be authenticated using an existing session.
+            See: http://bugs.adobe.com/jira/browse/FP-4830
+            For these cases, it is useful to disable the Flash-based uploader for Share Document Libraries.
+         -->
+         <adobe-flash-enabled>true</adobe-flash-enabled>
+      </file-upload>
+   </config>
+
+
+   <!-- Custom DocLibActions config section -->
+   <config evaluator="string-compare" condition="DocLibActions">
+      <actionGroups>
+         <actionGroup id="document-browse">
+
+            <!-- Simple Repo Actions -->
+            <!--
+            <action index="340" id="document-extract-metadata" />
+            <action index="350" id="document-increment-counter" />
+            -->
+
+            <!-- Dialog Repo Actions -->
+            <!--
+            <action index="360" id="document-transform" />
+            <action index="370" id="document-transform-image" />
+            <action index="380" id="document-execute-script" />
+            -->
+
+         </actionGroup>
+      </actionGroups>
+   </config>
+
+   <!-- Global folder picker config section -->
+   <config evaluator="string-compare" condition="GlobalFolder">
+      <siteTree>
+         <container type="cm:folder">
+            <!-- Use a specific label for this container type in the tree -->
+            <rootLabel>location.path.documents</rootLabel>
+            <!-- Use a specific uri to retreive the child nodes for this container type in the tree -->
+            <uri>slingshot/doclib/treenode/site/{site}/{container}{path}?children={evaluateChildFoldersSite}&amp;max={maximumFolderCountSite}</uri>
+         </container>
+      </siteTree>
+   </config>
+
+   <!-- Repository Library config section -->
+   <config evaluator="string-compare" condition="RepositoryLibrary" replace="true">
+      <!--
+         Root nodeRef or xpath expression for top-level folder.
+         e.g. alfresco://user/home, /app:company_home/st:sites/cm:site1
+         If using an xpath expression, ensure it is properly ISO9075 encoded here.
+      -->
+      <root-node>alfresco://company/home</root-node>
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>500</maximum-folder-count>
+      </tree>
+
+      <!--
+         Whether the link to the Repository Library appears in the header component or not.
+      -->
+      <visible>true</visible>
+   </config>
+   
+   <!-- Kerberos settings -->
+   <!-- To enable kerberos rename this condition to "Kerberos" -->
+   <config evaluator="string-compare" condition="KerberosDisabled" replace="true">
+      <kerberos>
+         <!--
+            Password for HTTP service account.
+            The account name *must* be built from the HTTP server name, in the format :
+               HTTP/<server_name>@<realm>
+            (NB this is because the web browser requests an ST for the
+            HTTP/<server_name> principal in the current realm, so if we're to decode
+            that ST, it has to match.)
+         -->
+         <password>secret</password>
+         <!--
+            Kerberos realm and KDC address.
+         -->
+         <realm>ALFRESCO.ORG</realm>
+         <!--
+            Service Principal Name to use on the repository tier.
+            This must be like: HTTP/host.name@REALM
+         -->
+         <endpoint-spn>HTTP/repository.server.com@ALFRESCO.ORG</endpoint-spn>
+         <!--
+            JAAS login configuration entry name.
+         -->
+         <config-entry>ShareHTTP</config-entry>
+        <!--
+           A Boolean which when true strips the @domain sufix from Kerberos authenticated usernames.
+           Use together with stripUsernameSuffix property in alfresco-global.properties file.
+        -->
+        <stripUserNameSuffix>true</stripUserNameSuffix>
+      </kerberos>
+   </config>
+
+   <!-- Uncomment and modify the URL to Activiti Admin Console if required. -->
+   <!--
+   <config evaluator="string-compare" condition="ActivitiAdmin" replace="true">
+      <activiti-admin-url>http://localhost:8080/alfresco/activiti-admin</activiti-admin-url>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <endpoint>
+            <id>alfresco-noauth</id>
+            <name>Alfresco - unauthenticated access</name>
+            <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>none</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco-feed</id>
+            <name>Alfresco Feed</name>
+            <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
+            <connector-id>http</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <basic-auth>true</basic-auth>
+            <identity>user</identity>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-api</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Public API - user access</name>
+            <description>Access to Alfresco Repository Public API that require user authentication.
+                         This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+      </remote>
+   </config>
+
+   <!-- 
+        Overriding endpoints to reference an Alfresco server with external SSO enabled
+        NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky
+              sessions" feature of your load balancer must be used.
+        NOTE: If alfresco server location is not localhost:8080 then also combine changes from the
+              "example port config" section below.
+        *Optional* ssl-config contains:
+              keystore for managing client key and certificate.
+              truststore for managing trusted CAs.
+        Used to authenticate share to an external SSO system such as CAS or 
+        to make share talk to SSL layers that require client certificates.
+        Remove the ssl-config section if not required i.e. for NTLM.
+        
+        NOTE: For Kerberos SSO rename the "KerberosDisabled" condition above to "Kerberos"
+        
+        NOTE: For external SSO, switch the endpoint connector to "alfrescoHeader" and set
+              the userHeader value to the name of the HTTP header that the external SSO
+              uses to provide the authenticated user name.
+        NOTE: For external SSO, Share now supports the "userIdPattern" mechanism as is available
+              on the repository config for External Authentication sub-system. Add the following
+              element to your "alfrescoHeader" connector config:
+              <userIdPattern>^ignore-(\w+)-ignore</userIdPattern>
+              This is an example, ensure the Id pattern matches your repository config.
+        NOTE: For external SSO, Share now supports stateless (no Http Session or sticky session)
+              connection to the repository when using the alfrescoHeader remote user connector.
+              e.g. You can change endpoint config to use the faster /service URL instead of the
+              /wcs URL if you are using External Authentication and then remove sticky session config
+              from your proxy between Share and Alfresco. Note that this is also faster because Share
+              will no longer call the /touch REST API before every remote call to the repository.
+   -->
+
+   <!-- Security warning -->
+   <!-- For production environment set verify-hostname to true.-->
+   <!--
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <ssl-config>
+            <keystore-path>alfresco/web-extension/alfresco-system.p12</keystore-path>
+            <keystore-type>pkcs12</keystore-type>
+            <keystore-password>alfresco-system</keystore-password>
+
+            <truststore-path>alfresco/web-extension/ssl-truststore</truststore-path>
+            <truststore-type>JCEKS</truststore-type>
+            <truststore-password>password</truststore-password>
+
+            <verify-hostname>true</verify-hostname>
+         </ssl-config>
+
+         <connector>
+            <id>alfrescoCookie</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+         </connector>
+         
+         <connector>
+            <id>alfrescoHeader</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using header and cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+            <userHeader>SsoUserHeader</userHeader>
+         </connector>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfrescoCookie</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-feed</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Feed</name>
+            <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description> 
+            <connector-id>alfrescoHeader</connector-id> 
+            <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-api</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Public API - user access</name>
+            <description>Access to Alfresco Repository Public API that require user authentication.
+                         This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
+            <connector-id>alfrescoHeader</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+      </remote>
+   </config>
+   -->
+
+   <!-- Cookie settings -->
+   <!-- To disable alfUsername2 cookie set enableCookie value to "false" -->
+   <!--
+   <plug-ins>
+      <element-readers>
+         <element-reader element-name="cookie" class="org.alfresco.web.config.cookie.CookieElementReader"/>
+      </element-readers>
+   </plug-ins>
+   
+   <config evaluator="string-compare" condition="Cookie" replace="true">
+      <cookie>
+         <enableCookie>false</enableCookie>
+         <cookies-to-remove>
+            <cookie-to-remove>alfUsername3</cookie-to-remove>
+            <cookie-to-remove>alfLogin</cookie-to-remove>
+         </cookies-to-remove>
+      </cookie>
+   </config>
+   -->
+</alfresco-config>

--- a/6.0/skeleton/local/share-config-custom.xml
+++ b/6.0/skeleton/local/share-config-custom.xml
@@ -210,7 +210,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -357,7 +357,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -366,7 +366,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -375,7 +375,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>
@@ -387,7 +387,7 @@
             <description>Access to Alfresco Repository Public API that require user authentication.
                          This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/api</endpoint-url>
             <identity>user</identity>
          </endpoint>
       </remote>

--- a/6.1/skeleton/local/share-config-custom.xml
+++ b/6.1/skeleton/local/share-config-custom.xml
@@ -1,0 +1,516 @@
+<alfresco-config>
+
+   <!-- Global config section -->
+   <config replace="true">
+      <flags>
+         <!--
+            Developer debugging setting to turn on DEBUG mode for client scripts in the browser
+         -->
+         <client-debug>false</client-debug>
+
+         <!--
+            LOGGING can always be toggled at runtime when in DEBUG mode (Ctrl, Ctrl, Shift, Shift).
+            This flag automatically activates logging on page load.
+         -->
+         <client-debug-autologging>false</client-debug-autologging>
+      </flags>
+   </config>
+   
+   <config evaluator="string-compare" condition="WebFramework">
+      <web-framework>
+         <!-- SpringSurf Autowire Runtime Settings -->
+         <!-- 
+              Developers can set mode to 'development' to disable; SpringSurf caches,
+              FreeMarker template caching and Rhino JavaScript compilation.
+         -->
+         <autowire>
+            <!-- Pick the mode: "production" or "development" -->
+            <mode>production</mode>
+         </autowire>
+
+         <!-- Allows extension modules with <auto-deploy> set to true to be automatically deployed -->
+         <module-deployment>
+            <mode>manual</mode>
+            <enable-auto-deploy-modules>true</enable-auto-deploy-modules>
+         </module-deployment>
+      </web-framework>
+   </config>
+
+   <!-- Disable the CSRF Token Filter -->
+   <!--
+   <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      <filter/>
+   </config>
+   -->
+
+   <!--
+      To run the CSRF Token Filter behind 1 or more proxies that do not rewrite the Origin or Referere headers:
+
+      1. Copy the "CSRFPolicy" default config in share-security-config.xml and paste it into this file.
+      2. Replace the old config by setting the <config> element's "replace" attribute to "true" like below:
+         <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+      3. To every <action name="assertReferer"> element add the following child element
+         <param name="referer">http://www.proxy1.com/.*|http://www.proxy2.com/.*</param>
+      4. To every <action name="assertOrigin"> element add the following child element
+         <param name="origin">http://www.proxy1.com|http://www.proxy2.com</param>
+   -->
+
+   <!--
+      Remove the default wildcard setting and use instead a strict whitelist of the only domains that shall be allowed
+      to be used inside iframes (i.e. in the WebView dashlet on the dashboards)
+   -->
+   <!--
+   <config evaluator="string-compare" condition="IFramePolicy" replace="true">
+      <cross-domain>
+         <url>http://www.trusted-domain-1.com/</url>
+         <url>http://www.trusted-domain-2.com/</url>
+      </cross-domain>
+   </config>
+   -->
+
+   <!-- Turn off header that stops Share from being displayed in iframes on pages from other domains -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>X-Frame-Options</name>
+            <enabled>false</enabled>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <!-- Prevent browser communication over HTTP (for HTTPS servers) -->
+   <!--
+   <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+      <headers>
+         <header>
+            <name>Strict-Transport-Security</name>
+            <value>max-age=31536000</value>
+         </header>
+      </headers>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Replication">
+      <share-urls>
+         <!--
+            To locate your current repositoryId go to Admin Console > General > Repository Information:
+              http://localhost:8080/alfresco/s/enterprise/admin/admin-repositoryinfo        
+
+            Example config entry:
+              <share-url repositoryId="622f9533-2a1e-48fe-af4e-ee9e41667ea4">http://new-york-office:8080/share/</share-url>
+         -->
+      </share-urls>
+   </config>
+
+   <!-- Document Library config section -->
+   <config evaluator="string-compare" condition="DocumentLibrary" replace="true">
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>1000</maximum-folder-count>
+         
+         <!--  
+            Default timeout in milliseconds for folder Tree component to recieve response from Repository
+         -->
+         <timeout>7000</timeout>
+      </tree>
+
+      <!--
+         Used by "Manage Rules" -> "Add aspect" action.
+
+         If an aspect has been specified without a title element in the content model,
+         or you need to support multiple languages,
+         then an i18n file is needed on the Repo AMP/JAR extension side for the aspect to
+         be visible when creating rules:
+
+          custom_customModel.aspect.custom_myaspect.title=My Aspect
+
+         Used by the "Manage Aspects" action.
+
+         For the aspect to have a localised label add relevant i18n string(s) in a Share AMP/JAR extension:
+
+          aspect.custom_myaspect=My Aspect
+      -->
+      <aspects>
+         <!-- Aspects that a user can see -->
+         <visible>
+            <aspect name="cm:generalclassifiable" />
+            <aspect name="cm:complianceable" />
+            <aspect name="cm:dublincore" />
+            <aspect name="cm:effectivity" />
+            <aspect name="cm:summarizable" />
+            <aspect name="cm:versionable" />
+            <aspect name="cm:templatable" />
+            <aspect name="cm:emailed" />
+            <aspect name="emailserver:aliasable" />
+            <aspect name="cm:taggable" />
+            <aspect name="app:inlineeditable" />
+            <aspect name="cm:geographic" />
+            <aspect name="exif:exif" />
+            <aspect name="audio:audio" />
+            <aspect name="cm:indexControl" />
+            <aspect name="dp:restrictable" />
+            <aspect name="smf:customConfigSmartFolder" />
+            <aspect name="smf:systemConfigSmartFolder" />
+         </visible>
+
+         <!-- Aspects that a user can add. Same as "visible" if left empty -->
+         <addable>
+         </addable>
+
+         <!-- Aspects that a user can remove. Same as "visible" if left empty -->
+         <removeable>
+         </removeable>
+      </aspects>
+
+      <!--
+         Used by "Manage Rules" -> "Specialise type" action.
+
+         If a type has been specified without a title element in the content model,
+         or you need to support multiple languages,
+         then an i18n file is needed on the Repo AMP/JAR extension side for the type to
+         be visible when creating rules:
+
+            custom_customModel.type.custom_mytype.title=My SubType
+
+         Used by the "Change Type" action.
+
+         For the type to have a localised label add relevant i18n string(s) in a Share AMP/JAR extension:
+
+            type.custom_mytype=My SubType
+
+         Define valid subtypes using the following example:
+
+            <type name="cm:content">
+             <subtype name="custom:mytype" />
+            </type>
+      -->
+      <types>
+         <type name="cm:content">
+            <subtype name="smf:smartFolderTemplate" />
+         </type>
+
+          <type name="cm:folder">
+         </type>
+
+         <type name="trx:transferTarget">
+            <subtype name="trx:fileTransferTarget" />
+         </type>
+      </types>
+
+      <!--
+         If set, will present a WebDAV link for the current item on the Document and Folder details pages.
+         Also used to generate the "View in Alfresco Explorer" action for folders.
+      -->
+      <repository-url>http://localhost:8080/alfresco</repository-url>
+
+      <!--
+         Google Docs™ integration
+      -->
+      <google-docs>
+         <!--
+            Enable/disable the Google Docs UI integration (Extra types on Create Content menu, Google Docs actions).
+         -->
+         <enabled>false</enabled>
+
+         <!--
+            The mimetypes of documents Google Docs allows you to create via the Share interface.
+            The I18N label is created from the "type" attribute, e.g. google-docs.doc=Google Docs&trade; Document
+         -->
+         <creatable-types>
+            <creatable type="doc">application/vnd.openxmlformats-officedocument.wordprocessingml.document</creatable>
+            <creatable type="xls">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</creatable>
+            <creatable type="ppt">application/vnd.ms-powerpoint</creatable>
+         </creatable-types>
+      </google-docs>
+
+      <!--
+         File upload configuration
+      -->
+      <file-upload>
+         <!--
+            Adobe Flash™
+            In certain environments, an HTTP request originating from Flash cannot be authenticated using an existing session.
+            See: http://bugs.adobe.com/jira/browse/FP-4830
+            For these cases, it is useful to disable the Flash-based uploader for Share Document Libraries.
+         -->
+         <adobe-flash-enabled>true</adobe-flash-enabled>
+      </file-upload>
+   </config>
+
+
+   <!-- Custom DocLibActions config section -->
+   <config evaluator="string-compare" condition="DocLibActions">
+      <actionGroups>
+         <actionGroup id="document-browse">
+
+            <!-- Simple Repo Actions -->
+            <!--
+            <action index="340" id="document-extract-metadata" />
+            <action index="350" id="document-increment-counter" />
+            -->
+
+            <!-- Dialog Repo Actions -->
+            <!--
+            <action index="360" id="document-transform" />
+            <action index="370" id="document-transform-image" />
+            <action index="380" id="document-execute-script" />
+            -->
+
+         </actionGroup>
+      </actionGroups>
+   </config>
+
+   <!-- Global folder picker config section -->
+   <config evaluator="string-compare" condition="GlobalFolder">
+      <siteTree>
+         <container type="cm:folder">
+            <!-- Use a specific label for this container type in the tree -->
+            <rootLabel>location.path.documents</rootLabel>
+            <!-- Use a specific uri to retreive the child nodes for this container type in the tree -->
+            <uri>slingshot/doclib/treenode/site/{site}/{container}{path}?children={evaluateChildFoldersSite}&amp;max={maximumFolderCountSite}</uri>
+         </container>
+      </siteTree>
+   </config>
+
+   <!-- Repository Library config section -->
+   <config evaluator="string-compare" condition="RepositoryLibrary" replace="true">
+      <!--
+         Root nodeRef or xpath expression for top-level folder.
+         e.g. alfresco://user/home, /app:company_home/st:sites/cm:site1
+         If using an xpath expression, ensure it is properly ISO9075 encoded here.
+      -->
+      <root-node>alfresco://company/home</root-node>
+
+      <tree>
+         <!--
+            Whether the folder Tree component should enumerate child folders or not.
+            This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+         -->
+         <evaluate-child-folders>false</evaluate-child-folders>
+         
+         <!--
+            Optionally limit the number of folders shown in treeview throughout Share.
+         -->
+         <maximum-folder-count>500</maximum-folder-count>
+      </tree>
+
+      <!--
+         Whether the link to the Repository Library appears in the header component or not.
+      -->
+      <visible>true</visible>
+   </config>
+   
+   <!-- Kerberos settings -->
+   <!-- To enable kerberos rename this condition to "Kerberos" -->
+   <config evaluator="string-compare" condition="KerberosDisabled" replace="true">
+      <kerberos>
+         <!--
+            Password for HTTP service account.
+            The account name *must* be built from the HTTP server name, in the format :
+               HTTP/<server_name>@<realm>
+            (NB this is because the web browser requests an ST for the
+            HTTP/<server_name> principal in the current realm, so if we're to decode
+            that ST, it has to match.)
+         -->
+         <password>secret</password>
+         <!--
+            Kerberos realm and KDC address.
+         -->
+         <realm>ALFRESCO.ORG</realm>
+         <!--
+            Service Principal Name to use on the repository tier.
+            This must be like: HTTP/host.name@REALM
+         -->
+         <endpoint-spn>HTTP/repository.server.com@ALFRESCO.ORG</endpoint-spn>
+         <!--
+            JAAS login configuration entry name.
+         -->
+         <config-entry>ShareHTTP</config-entry>
+        <!--
+           A Boolean which when true strips the @domain sufix from Kerberos authenticated usernames.
+           Use together with stripUsernameSuffix property in alfresco-global.properties file.
+        -->
+        <stripUserNameSuffix>true</stripUserNameSuffix>
+      </kerberos>
+   </config>
+
+   <!-- Uncomment and modify the URL to Activiti Admin Console if required. -->
+   <!--
+   <config evaluator="string-compare" condition="ActivitiAdmin" replace="true">
+      <activiti-admin-url>http://localhost:8080/alfresco/activiti-admin</activiti-admin-url>
+   </config>
+   -->
+
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <endpoint>
+            <id>alfresco-noauth</id>
+            <name>Alfresco - unauthenticated access</name>
+            <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>none</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+
+         <endpoint>
+            <id>alfresco-feed</id>
+            <name>Alfresco Feed</name>
+            <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
+            <connector-id>http</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <basic-auth>true</basic-auth>
+            <identity>user</identity>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-api</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Public API - user access</name>
+            <description>Access to Alfresco Repository Public API that require user authentication.
+                         This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
+            <connector-id>alfresco</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <identity>user</identity>
+         </endpoint>
+      </remote>
+   </config>
+
+   <!-- 
+        Overriding endpoints to reference an Alfresco server with external SSO enabled
+        NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky
+              sessions" feature of your load balancer must be used.
+        NOTE: If alfresco server location is not localhost:8080 then also combine changes from the
+              "example port config" section below.
+        *Optional* ssl-config contains:
+              keystore for managing client key and certificate.
+              truststore for managing trusted CAs.
+        Used to authenticate share to an external SSO system such as CAS or 
+        to make share talk to SSL layers that require client certificates.
+        Remove the ssl-config section if not required i.e. for NTLM.
+        
+        NOTE: For Kerberos SSO rename the "KerberosDisabled" condition above to "Kerberos"
+        
+        NOTE: For external SSO, switch the endpoint connector to "alfrescoHeader" and set
+              the userHeader value to the name of the HTTP header that the external SSO
+              uses to provide the authenticated user name.
+        NOTE: For external SSO, Share now supports the "userIdPattern" mechanism as is available
+              on the repository config for External Authentication sub-system. Add the following
+              element to your "alfrescoHeader" connector config:
+              <userIdPattern>^ignore-(\w+)-ignore</userIdPattern>
+              This is an example, ensure the Id pattern matches your repository config.
+        NOTE: For external SSO, Share now supports stateless (no Http Session or sticky session)
+              connection to the repository when using the alfrescoHeader remote user connector.
+              e.g. You can change endpoint config to use the faster /service URL instead of the
+              /wcs URL if you are using External Authentication and then remove sticky session config
+              from your proxy between Share and Alfresco. Note that this is also faster because Share
+              will no longer call the /touch REST API before every remote call to the repository.
+   -->
+
+   <!-- Security warning -->
+   <!-- For production environment set verify-hostname to true.-->
+   <!--
+   <config evaluator="string-compare" condition="Remote">
+      <remote>
+         <ssl-config>
+            <keystore-path>alfresco/web-extension/alfresco-system.p12</keystore-path>
+            <keystore-type>pkcs12</keystore-type>
+            <keystore-password>alfresco-system</keystore-password>
+
+            <truststore-path>alfresco/web-extension/ssl-truststore</truststore-path>
+            <truststore-type>JCEKS</truststore-type>
+            <truststore-password>password</truststore-password>
+
+            <verify-hostname>true</verify-hostname>
+         </ssl-config>
+
+         <connector>
+            <id>alfrescoCookie</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+         </connector>
+         
+         <connector>
+            <id>alfrescoHeader</id>
+            <name>Alfresco Connector</name>
+            <description>Connects to an Alfresco instance using header and cookie-based authentication</description>
+            <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+            <userHeader>SsoUserHeader</userHeader>
+         </connector>
+
+         <endpoint>
+            <id>alfresco</id>
+            <name>Alfresco - user access</name>
+            <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+            <connector-id>alfrescoCookie</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-feed</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Feed</name>
+            <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description> 
+            <connector-id>alfrescoHeader</connector-id> 
+            <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+         
+         <endpoint>
+            <id>alfresco-api</id>
+            <parent-id>alfresco</parent-id>
+            <name>Alfresco Public API - user access</name>
+            <description>Access to Alfresco Repository Public API that require user authentication.
+                         This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
+            <connector-id>alfrescoHeader</connector-id>
+            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <identity>user</identity>
+            <external-auth>true</external-auth>
+         </endpoint>
+      </remote>
+   </config>
+   -->
+
+   <!-- Cookie settings -->
+   <!-- To disable alfUsername2 cookie set enableCookie value to "false" -->
+   <!--
+   <plug-ins>
+      <element-readers>
+         <element-reader element-name="cookie" class="org.alfresco.web.config.cookie.CookieElementReader"/>
+      </element-readers>
+   </plug-ins>
+   
+   <config evaluator="string-compare" condition="Cookie" replace="true">
+      <cookie>
+         <enableCookie>false</enableCookie>
+         <cookies-to-remove>
+            <cookie-to-remove>alfUsername3</cookie-to-remove>
+            <cookie-to-remove>alfLogin</cookie-to-remove>
+         </cookies-to-remove>
+      </cookie>
+   </config>
+   -->
+</alfresco-config>

--- a/6.1/skeleton/local/share-config-custom.xml
+++ b/6.1/skeleton/local/share-config-custom.xml
@@ -212,7 +212,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -359,7 +359,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -368,7 +368,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -377,7 +377,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>
@@ -389,7 +389,7 @@
             <description>Access to Alfresco Repository Public API that require user authentication.
                          This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/api</endpoint-url>
             <identity>user</identity>
          </endpoint>
       </remote>

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton
@@ -20,6 +20,7 @@ RUN	mkdir -p /opt/alfresco && \
 	apt-get install -y curl unzip vim locate xmlstarlet jq && \
 	rm -rf ${CATALINA_HOME}/webapps/* && \
 	mkdir -p ${CATALINA_HOME}/bin && \
+	mkdir -p /docker-config && \
 	touch ${CATALINA_HOME}/bin/setenv.sh && \
 
     # Configure server.xml
@@ -82,6 +83,14 @@ RUN	chmod u+x /docker-entrypoint.d/90-init-alfresco.sh && \
 # permissions
  	chown -hR tomcat /opt/alfresco && \
 	chown -hR tomcat ${CATALINA_HOME} 
+
+# TO BE DEPRECATED: add share resources, to easily allow addition of a share war in derived images
+COPY	share-config-custom.xml /docker-config/
+COPY    91-init-share-customized.sh /docker-entrypoint.d/
+RUN	chmod u+x /docker-entrypoint.d/91-init-share-customized.sh && \
+    mkdir -p "${CATALINA_HOME}/shared/classes/alfresco/web-extension/" && \
+    chown -R tomcat:tomcat "${CATALINA_HOME}/shared/classes/alfresco/web-extension/"
+
 
 # named volumes
 VOLUME 	/opt/alfresco/alf_data ${CATALINA_HOME}/temp ${CATALINA_HOME}/logs

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton
@@ -17,7 +17,7 @@ USER	root
 # downloading ALF & components
 RUN	mkdir -p /opt/alfresco && \
 	apt-get update && \
-	apt-get install -y curl unzip vim locate xmlstarlet jq && \
+	apt-get install -y curl unzip vim locate xmlstarlet jq gettext-base && \
 	rm -rf ${CATALINA_HOME}/webapps/* && \
 	mkdir -p ${CATALINA_HOME}/bin && \
 	mkdir -p /docker-config && \

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
@@ -104,6 +104,14 @@ RUN	chmod u+x /docker-entrypoint.d/90-init-alfresco.sh && \
  	chown -hR tomcat /opt/alfresco && \
 	chown -hR tomcat ${CATALINA_HOME} 
 
+
+# TO BE DEPRECATED: add share resources, to easily allow addition of a share war in derived images
+COPY	share-config-custom.xml /docker-config/
+COPY    91-init-share-customized.sh /docker-entrypoint.d/
+RUN	chmod u+x /docker-entrypoint.d/91-init-share-customized.sh && \
+    mkdir -p "${CATALINA_HOME}/shared/classes/alfresco/web-extension/" && \
+    chown -R tomcat:tomcat "${CATALINA_HOME}/shared/classes/alfresco/web-extension/"
+
 # named volumes
 VOLUME 	/opt/alfresco/alf_data ${CATALINA_HOME}/temp ${CATALINA_HOME}/logs
 

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
@@ -21,7 +21,7 @@ ADD swftools_0.9.0-0ubuntu2_amd64.deb /tmp
 RUN	mkdir -p /opt/alfresco && \
     cd /opt/alfresco && \
 	apt-get update && \
-	apt-get install -y curl unzip vim locate xmlstarlet jq && \
+	apt-get install -y curl unzip vim locate xmlstarlet jq gettext-base && \
 
 	apt-get install -y ghostscript imagemagick && \
 	apt-get install -y libice6 libsm6 libxt6 libxrender1 libxinerama1 libfontconfig1 libcups2 libdbus-glib-1-2 libglu1 libreoffice && \

--- a/src/main/resources/global/91-init-share-customized.sh
+++ b/src/main/resources/global/91-init-share-customized.sh
@@ -11,7 +11,12 @@ ALFRESCO_PORT=${ALFRESCO_PORT:-8080}
 ALFRESCO_PROTOCOL=${ALFRESCO_PROTOCOL:-http}
 ALFRESCO_CONTEXT=${ALFRESCO_CONTEXT:-alfresco}
 
-sed -e 's/http:\/\/localhost:8080\/alfresco/'"$ALFRESCO_PROTOCOL"':\/\/'"$ALFRESCO_HOST"':'"$ALFRESCO_PORT"'\/'"$ALFRESCO_CONTEXT"'/g' </docker-config/share-config-custom.xml >"${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml"
+export ALFRESCO_HOST
+export ALFRESCO_PORT
+export ALFRESCO_PROTOCOL
+export ALFRESCO_CONTEXT
+
+envsubst </docker-config/share-config-custom.xml >"${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml"
 
 echo "Share init done"
 fi

--- a/src/main/resources/global/91-init-share-customized.sh
+++ b/src/main/resources/global/91-init-share-customized.sh
@@ -6,32 +6,12 @@ set -e
 if [ -d "$CATALINA_HOME/webapps/share" ]; then
 echo "Share init start"
 
-JAVA_XMS=${JAVA_XMS:-'512M'}
-JAVA_XMX=${JAVA_XMX:-'2048M'}
-DEBUG=${DEBUG:-'false'}
-JMX_ENABLED=${JMX_ENABLED:-'false'}
-JMX_RMI_HOST=${JMX_RMI_HOST:-'0.0.0.0'}
-
-
 ALFRESCO_HOST=${ALFRESCO_HOST:-alfresco}
 ALFRESCO_PORT=${ALFRESCO_PORT:-8080}
 ALFRESCO_PROTOCOL=${ALFRESCO_PROTOCOL:-http}
 ALFRESCO_CONTEXT=${ALFRESCO_CONTEXT:-alfresco}
 
 sed -e 's/http:\/\/localhost:8080\/alfresco/'"$ALFRESCO_PROTOCOL"':\/\/'"$ALFRESCO_HOST"':'"$ALFRESCO_PORT"'\/'"$ALFRESCO_CONTEXT"'/g' </docker-config/share-config-custom.xml >"${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml"
-
-setJavaOption "defaults" "-Xms$JAVA_XMS -Xmx$JAVA_XMX -Dfile.encoding=UTF-8"
-
-if [ $DEBUG = true ]
-then
-    setJavaOption "debug" "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:8000"
-fi
-
-if [ $JMX_ENABLED = true ]
-then
-    # be sure port 5000 is mapped on the host also on 5000
-    setJavaOption "jmx" "-Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.rmi.port=5000 -Dcom.sun.management.jmxremote.port=5000 -Djava.rmi.server.hostname=${JMX_RMI_HOST}"
-fi
 
 echo "Share init done"
 fi

--- a/src/main/resources/global/91-init-share-customized.sh
+++ b/src/main/resources/global/91-init-share-customized.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# we should get env ${CATALINA_HOME} from upstream container docker
+set -e
+
+if [ -d "$CATALINA_HOME/webapps/share" ]; then
+echo "Share init start"
+
+JAVA_XMS=${JAVA_XMS:-'512M'}
+JAVA_XMX=${JAVA_XMX:-'2048M'}
+DEBUG=${DEBUG:-'false'}
+JMX_ENABLED=${JMX_ENABLED:-'false'}
+JMX_RMI_HOST=${JMX_RMI_HOST:-'0.0.0.0'}
+
+
+ALFRESCO_HOST=${ALFRESCO_HOST:-alfresco}
+ALFRESCO_PORT=${ALFRESCO_PORT:-8080}
+ALFRESCO_PROTOCOL=${ALFRESCO_PROTOCOL:-http}
+ALFRESCO_CONTEXT=${ALFRESCO_CONTEXT:-alfresco}
+
+sed -e 's/http:\/\/localhost:8080\/alfresco/'"$ALFRESCO_PROTOCOL"':\/\/'"$ALFRESCO_HOST"':'"$ALFRESCO_PORT"'\/'"$ALFRESCO_CONTEXT"'/g' </docker-config/share-config-custom.xml >"${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml"
+
+setJavaOption "defaults" "-Xms$JAVA_XMS -Xmx$JAVA_XMX -Dfile.encoding=UTF-8"
+
+if [ $DEBUG = true ]
+then
+    setJavaOption "debug" "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:8000"
+fi
+
+if [ $JMX_ENABLED = true ]
+then
+    # be sure port 5000 is mapped on the host also on 5000
+    setJavaOption "jmx" "-Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.rmi.port=5000 -Dcom.sun.management.jmxremote.port=5000 -Djava.rmi.server.hostname=${JMX_RMI_HOST}"
+fi
+
+echo "Share init done"
+fi


### PR DESCRIPTION
Most of current clients at Xenit still use the image with Alfresco+Share inside. To make the transition to split images, it is convenient to have an intermediate step in which all resources necessary to share (except the war) are included in the Alfresco image.