### PR TITLE
DOCKER-292: modernize transformation stack for Alfresco 6x

### DIFF
--- a/2repository/build.gradle
+++ b/2repository/build.gradle
@@ -149,6 +149,11 @@ subprojects {
             } else {
                 useComposeFiles = ["$composeDir/docker-compose-alfresco.yml", "$composeDir/docker-compose-share.yml",
                                    "$composeDir/docker-compose-solr.yml", "$composeDir/docker-compose-db.yml", "$composeDir/docker-compose-transformers.yml"];
+		if (project.alfresco.flavor == "enterprise") {
+                    useComposeFiles = ["$composeDir/docker-compose-alfresco.yml", "$composeDir/docker-compose-share.yml",
+                                       "$composeDir/docker-compose-solr.yml", "$composeDir/docker-compose-db.yml", "$composeDir/docker-compose-transformers.yml", "$composeDir/docker-compose-enterprise-only.yml"];		    
+		}
+		
             }
 
             changedPorts {

--- a/2repository/src/integrationTest/resources/docker-compose-alfresco.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-alfresco.yml
@@ -9,7 +9,18 @@ services:
      - postgresql
    environment:
    - SOLR_HOST=solr
+   # this is not actually needed unless custom transformers have been deployed
+   - GLOBAL_legacy.transform.service.enabled=true
    - GLOBAL_alfresco-pdf-renderer.url=http://alfresco-pdf-renderer:8090/ # from Alfresco 6.0 on
    - GLOBAL_jodconverter.url=http://libreoffice:8090/ # from Alfresco 6.0 on
    - GLOBAL_img.url=http://imagemagick:8090/ # from Alfresco 6.0 on
    - GLOBAL_tika.url=http://tika:8090/  # from Alfresco 6.1 on
+   - GLOBAL_transform.misc.url=http://transform-misc:8090/  # from Alfresco 6.1 on
+   # works on both community and enterprise
+   - GLOBAL_local.transform.service.enabled=true
+   - GLOBAL_localTransform.pdfrenderer.url=http://alfresco-pdf-renderer:8090/
+   - GLOBAL_localTransform.imagemagick.url=http://imagemagick:8090/
+   - GLOBAL_localTransform.libreoffice.url=http://libreoffice:8090/
+   - GLOBAL_localTransform.tika.url=http://tika:8090/
+   - GLOBAL_localTransform.misc.url=http://transform-misc:8090/
+

--- a/2repository/src/integrationTest/resources/docker-compose-alfresco.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-alfresco.yml
@@ -9,14 +9,14 @@ services:
      - postgresql
    environment:
    - SOLR_HOST=solr
-   # this is not actually needed unless custom transformers have been deployed
+   # this is not actually needed unless custom transformers have been deployed or as a fallback
    - GLOBAL_legacy.transform.service.enabled=true
    - GLOBAL_alfresco-pdf-renderer.url=http://alfresco-pdf-renderer:8090/ # from Alfresco 6.0 on
    - GLOBAL_jodconverter.url=http://libreoffice:8090/ # from Alfresco 6.0 on
    - GLOBAL_img.url=http://imagemagick:8090/ # from Alfresco 6.0 on
    - GLOBAL_tika.url=http://tika:8090/  # from Alfresco 6.1 on
    - GLOBAL_transform.misc.url=http://transform-misc:8090/  # from Alfresco 6.1 on
-   # works on both community and enterprise
+   # works on both community (from Alfresco 6.2) and enterprise
    - GLOBAL_local.transform.service.enabled=true
    - GLOBAL_localTransform.pdfrenderer.url=http://alfresco-pdf-renderer:8090/
    - GLOBAL_localTransform.imagemagick.url=http://imagemagick:8090/

--- a/2repository/src/integrationTest/resources/docker-compose-enterprise-only.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-enterprise-only.yml
@@ -1,0 +1,44 @@
+version: '3'
+
+services:
+  alfresco:
+     image: ${DOCKER_IMAGE}
+     environment:
+       - GLOBAL_messaging.subsystem.autoStart=true
+       - "GLOBAL_messaging.broker.url=failover:(nio://activemq:61616)?timeout=3000&jms.useCompression=true"
+       - GLOBAL_local.transform.service.enabled=false
+       - GLOBAL_transform.service.enabled=true
+       - GLOBAL_transform.service.url=http://transform-router:8095
+       - GLOBAL_sfs.url=http://shared-file-store:8099/     
+  transform-router:
+     image: quay.io/alfresco/alfresco-transform-router:1.1.0
+     environment:
+        JAVA_OPTS: " -Xms256m -Xmx512m"
+        ACTIVEMQ_URL: "nio://activemq:61616"
+        IMAGEMAGICK_URL: "http://imagemagick:8090"
+        PDF_RENDERER_URL : "http://alfresco-pdf-renderer:8090"
+        LIBREOFFICE_URL : "http://libreoffice:8090"
+        TIKA_URL : "http://tika:8090"
+        MISC_URL : "http://transform-misc:8090"
+        FILE_STORE_URL: "http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file"
+  shared-file-store:
+     image: alfresco/alfresco-shared-file-store:0.5.3
+     environment:
+        JAVA_OPTS: " -Xms256m -Xmx512m"
+        scheduler.content.age.millis: 86400000
+        scheduler.cleanup.interval: 86400000
+     volumes:
+        - shared-file-store-volume:/tmp/Alfresco/sfs
+  activemq:
+     image: alfresco/alfresco-activemq:5.15.8
+     ports:
+       - 8161:8161 # Web Console
+       - 5672:5672 # AMQP
+       - 61616:61616 # OpenWire
+       - 61613:61613 # STOMP
+
+volumes:
+    shared-file-store-volume:
+        driver_opts:
+            type: tmpfs
+            device: tmpfs

--- a/2repository/src/integrationTest/resources/docker-compose-transformers.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-transformers.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
  alfresco-pdf-renderer:
-   image: alfresco/alfresco-pdf-renderer:0.9
+   image: alfresco/alfresco-pdf-renderer:2.1.0
    environment:
      JAVA_OPTS: " -Xms256m -Xmx512m"
 
@@ -12,13 +12,19 @@ services:
      JAVA_OPTS: " -Xms256m -Xmx512m"
 
  imagemagick:
-   image: alfresco/alfresco-imagemagick:0.9
+   image: alfresco/alfresco-imagemagick:2.1.0
    environment:
      JAVA_OPTS: " -Xms256m -Xmx512m"
 
  # only works from Alfresco 6.1 on
  tika:
-   image: alfresco/alfresco-tika:1.2
+   image: alfresco/alfresco-tika:2.1.0
+   environment:
+     JAVA_OPTS: " -Xms256m -Xmx512m"
+
+ # only works from Alfresco 6.1 on
+ tika:
+   image: alfresco/alfresco-transform-misc:2.1.0
    environment:
      JAVA_OPTS: " -Xms256m -Xmx512m"
 


### PR DESCRIPTION
1) Bump versions transformers.
2) For enterprise use the transform router + queue-based transformations.