### PR TITLE
DOCKER-294: install fontconfig

### DIFF
--- a/src/main/resources/dockerfiles/Dockerfile-skeleton
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton
@@ -17,7 +17,7 @@ USER	root
 # downloading ALF & components
 RUN	mkdir -p /opt/alfresco && \
 	apt-get update && \
-	apt-get install -y curl unzip vim locate xmlstarlet jq gettext-base && \
+	apt-get install -y curl unzip vim locate xmlstarlet jq gettext-base fontconfig && \
 	rm -rf ${CATALINA_HOME}/webapps/* && \
 	mkdir -p ${CATALINA_HOME}/bin && \
 	touch ${CATALINA_HOME}/bin/setenv.sh && \


### PR DESCRIPTION
@evyrosseels: I think that the issue you reported in docker-openjdk should actually be solved at this level:
https://github.com/xenit-eu/docker-openjdk/issues/6