### PR TITLE
DOCKER-284 Allow setting logger levels through docker-compose

### DIFF
--- a/2repository/build.gradle
+++ b/2repository/build.gradle
@@ -25,6 +25,9 @@ subprojects {
         integrationTestImplementation group: 'io.rest-assured', name: 'rest-assured-common', version: '3.0.1'
         integrationTestImplementation group: 'junit', name: 'junit', version: '4.11'
         integrationTestImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+        integrationTestImplementation "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
+        integrationTestImplementation "org.glassfish.jaxb:jaxb-runtime:2.3.2"
+
     }
 
 

--- a/docker-init-script/build.gradle
+++ b/docker-init-script/build.gradle
@@ -17,7 +17,7 @@ jar {
 
 jacocoTestReport {
     reports {
-        html.destination("${buildDir}/reports/jacocoHtml")
+        html.destination(file("${buildDir}/reports/jacocoHtml"))
     }
     mustRunAfter(test)
 }

--- a/docker-init-script/src/test/java/eu/xenit/docker/alfresco/InitScriptMainTest.java
+++ b/docker-init-script/src/test/java/eu/xenit/docker/alfresco/InitScriptMainTest.java
@@ -121,8 +121,8 @@ public class InitScriptMainTest {
         InitScriptMain main = new InitScriptMain(environment, new HashMap<String, String>(), log4jProperties);
         main.process();
         // load properties
-        Map<String, String> expectedProperties = new HashMap<>();
-        String filename = "testSetCustomLoggerLevels/default.properties";
+        Map<String, String> expectedProperties;
+        String filename = testName + "/default.properties";
         try (InputStream propertiesInputStream = getClass().getResourceAsStream(filename)) {
             Properties props = new Properties();
             if (propertiesInputStream != null) {

--- a/docker-init-script/src/test/java/eu/xenit/docker/alfresco/InitScriptMainTest.java
+++ b/docker-init-script/src/test/java/eu/xenit/docker/alfresco/InitScriptMainTest.java
@@ -109,10 +109,29 @@ public class InitScriptMainTest {
 
     private InitScriptMain checkProperties(String testName, Map<String, String> environment) throws IOException {
         Map<String, String> globalProperties = new HashMap<>();
-        InitScriptMain main = new InitScriptMain(environment, globalProperties);
+        InitScriptMain main = new InitScriptMain(environment, globalProperties, new HashMap<String, String>());
         main.process();
         Map<String, String> expectedProperties = loadProperties(testName);
         mapDifference(expectedProperties, globalProperties);
+        return main;
+    }
+
+    private InitScriptMain checkLoggers(String testName, Map<String, String> environment) throws IOException {
+        Map<String, String> log4jProperties = new HashMap<>();
+        InitScriptMain main = new InitScriptMain(environment, new HashMap<String, String>(), log4jProperties);
+        main.process();
+        // load properties
+        Map<String, String> expectedProperties = new HashMap<>();
+        String filename = "testSetCustomLoggerLevels/default.properties";
+        try (InputStream propertiesInputStream = getClass().getResourceAsStream(filename)) {
+            Properties props = new Properties();
+            if (propertiesInputStream != null) {
+                props.load(propertiesInputStream);
+            }
+            expectedProperties = (Map) props;
+        }
+        // comparison
+        mapDifference(expectedProperties, log4jProperties);
         return main;
     }
 
@@ -184,6 +203,13 @@ public class InitScriptMainTest {
         env.put("GLOBAL_test.global.property", "value");
         env.put("GLOBAL_test.*.property", "value2");
         checkProperties("testSetCustomGlobalProperties", env);
+    }
+
+    @Test
+    public void testSetCustomLoggerLevels() throws IOException {
+        Map<String, String> env = getDefaultEnvironment();
+        env.put("LOG4J_logger.eu.xenit.test", "DEBUG");
+        checkLoggers("testSetCustomLoggerLevels", env);
     }
 
 }

--- a/docker-init-script/src/test/resources/eu/xenit/docker/alfresco/testSetCustomLoggerLevels/default.properties
+++ b/docker-init-script/src/test/resources/eu/xenit/docker/alfresco/testSetCustomLoggerLevels/default.properties
@@ -1,0 +1,1 @@
+log4j.logger.eu.xenit.test=DEBUG

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/global/90-init-alfresco.sh
+++ b/src/main/resources/global/90-init-alfresco.sh
@@ -12,10 +12,11 @@ export SOLR_SSL=${SOLR_SSL:-'https'}
 export JAVA_OPTS
 
 CONFIG_FILE=${CONFIG_FILE:-${CATALINA_HOME}'/shared/classes/alfresco-global.properties'}
+LOG4J_CONFIG_FILE=${LOG4J_CONFIG_FILE:-${CATALINA_HOME}'/webapps/alfresco/WEB-INF/classes/alfresco/extension/dev-log4j.properties'}
 TOMCAT_CONFIG_FILE=${CATALINA_HOME}'/bin/setenv.sh'
 TOMCAT_SERVER_FILE=${CATALINA_HOME}'/conf/server.xml'
 
-${JAVA_HOME}/bin/java -jar /90-init-alfresco.jar "$CONFIG_FILE" "$TOMCAT_CONFIG_FILE"
+${JAVA_HOME}/bin/java -jar /90-init-alfresco.jar "$CONFIG_FILE" "$TOMCAT_CONFIG_FILE" "$LOG4J_CONFIG_FILE"
 
 if [[ $SOLR_SSL == none ]] && [[ $ALFRESCO_VERSION != "5.0"* ]] && [[ $ALFRESCO_VERSION != "3"* ]] && [[ $ALFRESCO_VERSION != "4"* ]]; then
   #remove the SSL connector


### PR DESCRIPTION
This extends `InitScriptMain` to allow setting log4j properties in a similar fashion as we can already set global properties. This can be done by using an environment variable starting with `LOG4J_` which will be translated to a property starting with `log4j.`. The options that can be set in this fashion aren't limited to logger levels, but include anything that can be set with `log4j.`, such as appender settings.

This fixes https://github.com/xenit-eu/docker-alfresco/issues/20 