### PR TITLE
DOCKER-311 Compare dir owners by user id

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 * [DOCKER-251] Init script was duplicating JAVA_OPTS_<var> variables
+* [DOCKER-311] alf_data owner comparison used user name rather than user id
 
 ## [v1.0.0] Make it public
 ### Changed

--- a/src/main/resources/global/90-init-alfresco.sh
+++ b/src/main/resources/global/90-init-alfresco.sh
@@ -25,12 +25,12 @@ fi
 
 if [ -n "$CATALINA_HOME" ]; then
 
-  user="tomcat"
-  if [[ $(stat -c %U /opt/alfresco/alf_data) != "$user" ]]; then
-    chown -R $user:$user /opt/alfresco/alf_data
+  userid="$(id -u tomcat)"
+  if [[ $(stat -c %u /opt/alfresco/alf_data) != "$userid" ]]; then
+    chown -R $userid:$userid /opt/alfresco/alf_data
   fi
-  if [[ $(stat -c %U "$CATALINA_HOME/temp") != "$user" ]]; then
-    chown -R $user:$user "$CATALINA_HOME"/temp
+  if [[ $(stat -c %u "$CATALINA_HOME/temp") != "$userid" ]]; then
+    chown -R $userid:$userid "$CATALINA_HOME"/temp
   fi
 
 fi


### PR DESCRIPTION
Docker-alfresco chowns the alf_data directory if it's not owned by the user "tomcat". However, the alf_data directory is frequently mounted, which instead lists the owner as a numeric id (990). It should check whether the numeric user id matches that of the user tomcat before deciding whether to chown a (potentially very large) directory.