### PR TITLE
Docker 312: start a release procedure

### DIFF
--- a/1skeleton/build.gradle
+++ b/1skeleton/build.gradle
@@ -65,7 +65,9 @@ subprojects {
                 'ALFRESCO_VERSION_MINOR': "${project.alfresco.version.minor}",
                 'ALFRESCO_VERSION_REV'  : "${project.alfresco.version.rev}",
                 'ALFRESCO_FLAVOR'       : "${project.alfresco.flavor}",
-                'BASE_IMAGE'            : "docker.io/xenit/tomcat:alfresco-${project.alfresco.version.major}.${project.alfresco.version.minor}-ubuntu"
+                'BASE_IMAGE'            : "docker.io/xenit/tomcat:alfresco-${project.alfresco.version.major}.${project.alfresco.version.minor}-ubuntu",
+  	        'XENIT_VERSION'         :  xenitVersion
+	    
         ] << (project.hasProperty('extraBuildArgs')?project.extraBuildArgs:[:])
 
 

--- a/1skeleton/build.gradle
+++ b/1skeleton/build.gradle
@@ -66,7 +66,7 @@ subprojects {
                 'ALFRESCO_VERSION_REV'  : "${project.alfresco.version.rev}",
                 'ALFRESCO_FLAVOR'       : "${project.alfresco.flavor}",
                 'BASE_IMAGE'            : "docker.io/xenit/tomcat:alfresco-${project.alfresco.version.major}.${project.alfresco.version.minor}-ubuntu",
-  	        'XENIT_VERSION'         :  xenitVersion
+                'XENIT_VERSION'         :  xenitVersion
 	    
         ] << (project.hasProperty('extraBuildArgs')?project.extraBuildArgs:[:])
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,14 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## Unreleased v1.0.1-SNAPSHOT
 ### Added
 * [DOCKER-266] Added enterprise 5.2.6
 * [DOCKER-291] Added enterprise 6.2.0 and community 6.2.0-ga
 * [DOCKER-309] Added enterprise 6.1.1
-* [DOCKER-294]: install fontconfig in the skeleton image
-* [DOCKER-284]: allow setting log levels through docker-compose
-
+* [DOCKER-294]: Install fontconfig in the skeleton image
+* [DOCKER-284]: Allow setting log levels through docker-compose
+* [DOCKER-312]: Start a release procedure: add Xenit version to the images tags
+	
 ### Changed
 * [DOCKER-278] Move java specific variables (jmx, debug, memory settings) to java layer
 * [DOCKER-236] Separate out share: see https://github.com/xenit-eu/docker-share

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 * [DOCKER-266] Added enterprise 5.2.6
+* [DOCKER-291] Added enterprise 6.2.0 and community 6.2.0-ga
+* [DOCKER-309] Added enterprise 6.1.1
+* [DOCKER-294]: install fontconfig in the skeleton image
+* [DOCKER-284]: allow setting log levels through docker-compose
 
 ### Changed
 * [DOCKER-278] Move java specific variables (jmx, debug, memory settings) to java layer
@@ -14,9 +18,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [DOCKER-255] Continue to build some legacy images, with both Alfresco and Share inside
 * [DOCKER-253] Move handling of properties to Java code instead of shell in the init
 * [DOCKER-263], [DOCKER-259], [DOCKER-258], [DOCKER-257], [DOCKER-256] Refactorings, better handling of failures, notifications
+* [DOCKER-292] Bump versions transformers. Use transform router + queue based transformations.	
+* Increase number of tries in healthcheck
+* Upgrade gradle and docker-alfresco plugin
+* Use smartCopy functionality
+* Disable pulling imag when using an image id
 
 ### Fixed
 * [DOCKER-251] Init script was duplicating JAVA_OPTS_<var> variables
+* [DOCKER-288] Make sure java executable points to the Adopt openjdk
 
 ## [v1.0.0] Make it public
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [DOCKER-266] Added enterprise 5.2.6
 * [DOCKER-291] Added enterprise 6.2.0 and community 6.2.0-ga
 * [DOCKER-309] Added enterprise 6.1.1
-* [DOCKER-294]: Install fontconfig in the skeleton image
-* [DOCKER-284]: Allow setting log levels through docker-compose
-* [DOCKER-312]: Start a release procedure: add Xenit version to the images tags
+* [DOCKER-294] Install fontconfig in the skeleton image
+* [DOCKER-284] Allow setting log levels through docker-compose
+* [DOCKER-312] Start a release procedure: add Xenit version to the images tags
 	
 ### Changed
 * [DOCKER-278] Move java specific variables (jmx, debug, memory settings) to java layer

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased v1.0.1-SNAPSHOT
+## Unreleased
 ### Added
 * [DOCKER-266] Added enterprise 5.2.6
 * [DOCKER-291] Added enterprise 6.2.0 and community 6.2.0-ga

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Increase number of tries in healthcheck
 * Upgrade gradle and docker-alfresco plugin
 * Use smartCopy functionality
-* Disable pulling imag when using an image id
+* Disable pulling image when using an image id
 
 ### Fixed
 * [DOCKER-251] Init script was duplicating JAVA_OPTS_<var> variables
@@ -152,4 +152,3 @@ Correct way to change those - via TOMCAT_PORT and TOMCAT_PORT_SSL.
 * [DOCKER-37] Removed bundled images for versions >=5.0
 * [DOCKER-26] Removed the PROXY_<variable> parameters from the init
 	
-

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@ plugins {
 }
 
 static def calcTags(version) {
+    def xenitVersion="1.0.1-SNAPSHOT"
     def tags = [
-            "${version.major}.${version.minor}.${version.rev}".toString(),
-            "${version.major}.${version.minor}".toString()
+        "${version.major}.${version.minor}.${version.rev}x${xenitVersion}".toString(),
+        "${version.major}.${version.minor}x${xenitVersion}".toString()
     ]
 
     if (version.label) {

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,9 @@ plugins {
 }
 
 static def calcTags(version) {
-    def xenitVersion="1.0.1-SNAPSHOT"
     def tags = [
-        "${version.major}.${version.minor}.${version.rev}x${xenitVersion}".toString(),
-        "${version.major}.${version.minor}x${xenitVersion}".toString()
+        "${version.major}.${version.minor}.${version.rev}".toString(),
+        "${version.major}.${version.minor}".toString()
     ]
 
     if (version.label) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+xenitVersion=1.0.1-SNAPSHOT

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton
@@ -91,6 +91,6 @@ WORKDIR /opt/alfresco
 
 HEALTHCHECK --interval=10s --timeout=3s --retries=30 --start-period=20s CMD curl -f http://localhost:${TOMCAT_PORT}/alfresco/s/api/server || exit 1
 
-LABEL xenitVersion=$XENIT_VERSION
+LABEL eu.xenit.docker.docker-alfresco.version=$XENIT_VERSION
 
 # start ALF will be done by java image's entrypoint + tomcat image's CMD

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton
@@ -5,6 +5,7 @@ ARG ALFRESCO_VERSION_MAJOR
 ARG ALFRESCO_VERSION_MINOR
 ARG ALFRESCO_VERSION_REV
 ARG ALFRESCO_FLAVOR
+ARG XENIT_VERSION
 
 # ${CATALINA_HOME} is set to ${CATALINA_HOME} in upstream
 
@@ -89,5 +90,7 @@ VOLUME 	/opt/alfresco/alf_data ${CATALINA_HOME}/temp ${CATALINA_HOME}/logs
 WORKDIR /opt/alfresco
 
 HEALTHCHECK --interval=10s --timeout=3s --retries=30 --start-period=20s CMD curl -f http://localhost:${TOMCAT_PORT}/alfresco/s/api/server || exit 1
+
+LABEL xenitVersion=$XENIT_VERSION
 
 # start ALF will be done by java image's entrypoint + tomcat image's CMD


### PR DESCRIPTION
Each commit should ideally be referred to in the Changelog.

Once a significant set of commits can form a release, the xenitVersion should be changed in the build.gradle from a SNAPSHOT to a real release (e.g. 1.0.1-SNAPSHOT => 1.0.1), and the change should be reflected in the Changelog. 

A subsequent commit can prepare the following release, by starting the following SNAPSHOT.