### PR TITLE
[Docker 321] Tomcat SSL connector no longer configured since upgrade to latest version

### DIFF
--- a/2repository/src/integrationTest/resources/docker-compose-alfresco.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-alfresco.yml
@@ -5,6 +5,7 @@ services:
    image: ${DOCKER_IMAGE}
    ports:
      - 8080
+     - 8443
    depends_on:
      - postgresql
    environment:

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton
@@ -25,8 +25,7 @@ RUN	mkdir -p /opt/alfresco && \
 
     # Configure server.xml
     xmlstarlet edit --inplace \
-        --var connector "/Server/Service[@name='Catalina']/Connector[@protocol=\"AJP/1.3\"]" \
-        --append '$connector' --type elem --name Connector \
+        --append "/Server/Service/Connector" --type elem --name Connector \
             --var connector '$prev' \
             --insert '$connector' --type attr --name port --value \$\{TOMCAT_PORT_SSL\} \
             --insert '$connector' --type attr --name URIEncoding --value UTF-8 \
@@ -49,8 +48,8 @@ RUN	mkdir -p /opt/alfresco && \
             --insert '$connector' --type attr --name maxSavePostSize --value -1 \
         ${CATALINA_HOME}/conf/server.xml && \
 
-    xmlstarlet edit --inplace \
-        --subnode "/tomcat-users" --type elem --name user \
+    xmlstarlet edit --inplace -N apache="http://tomcat.apache.org/xml" \
+        --subnode "/apache:tomcat-users" --type elem --name user \
             --var user '$prev' \
             --insert '$user' --type attr --name username --value "CN=Alfresco Repository Client, OU=Unknown, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB" \
             --insert '$user' --type attr --name roles --value "repoclient" \

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
@@ -49,8 +49,7 @@ RUN	mkdir -p /opt/alfresco && \
 
     # Configure server.xml
     xmlstarlet edit --inplace \
-        --var connector "/Server/Service[@name='Catalina']/Connector[@protocol=\"AJP/1.3\"]" \
-        --append '$connector' --type elem --name Connector \
+        --append "/Server/Service/Connector" --type elem --name Connector \
             --var connector '$prev' \
             --insert '$connector' --type attr --name port --value \$\{TOMCAT_PORT_SSL\} \
             --insert '$connector' --type attr --name URIEncoding --value UTF-8 \
@@ -73,8 +72,8 @@ RUN	mkdir -p /opt/alfresco && \
             --insert '$connector' --type attr --name maxSavePostSize --value -1 \
         ${CATALINA_HOME}/conf/server.xml && \
 
-    xmlstarlet edit --inplace \
-        --subnode "/tomcat-users" --type elem --name user \
+    xmlstarlet edit --inplace -N apache="http://tomcat.apache.org/xml" \
+        --subnode "/apache:tomcat-users" --type elem --name user \
             --var user '$prev' \
             --insert '$user' --type attr --name username --value "CN=Alfresco Repository Client, OU=Unknown, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB" \
             --insert '$user' --type attr --name roles --value "repoclient" \


### PR DESCRIPTION
Make sure SSL connector is added again on latest versions of Tomcat.