### PR TITLE
DOCKER-335: Don't delete too much when deleting SSL Connector

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 * [DOCKER-251] Init script was duplicating JAVA_OPTS_<var> variables
 * [DOCKER-288] Make sure java executable points to the Adopt openjdk
+* [DOCKER-335] Fix bug where `SOLR_SSL=none` deleted too much from server.xml
 
 ## [v1.0.0] Make it public
 ### Changed

--- a/src/main/resources/global/90-init-alfresco.sh
+++ b/src/main/resources/global/90-init-alfresco.sh
@@ -21,7 +21,7 @@ ${JAVA_HOME}/bin/java -jar /90-init-alfresco.jar "$CONFIG_FILE" "$TOMCAT_CONFIG_
 if [[ $SOLR_SSL == none ]] && [[ $ALFRESCO_VERSION != "5.0"* ]] && [[ $ALFRESCO_VERSION != "3"* ]] && [[ $ALFRESCO_VERSION != "4"* ]]; then
   #remove the SSL connector
   apt-get update && apt-get install -y xmlstarlet #TODO: remove this when xml-starlet is no longer purged in docker-tomcat
-  xmlstarlet edit --inplace --delete "/Server/Service[@name='Catalina']/Connector[@SSLEnabled='true']" $TOMCAT_SERVER_FILE
+  xmlstarlet edit --inplace --delete "/Server/Service[@name='Catalina']/Connector[@SSLEnabled='true' and @port='\${TOMCAT_PORT_SSL}']" $TOMCAT_SERVER_FILE
 fi
 
 if [ -n "$CATALINA_HOME" ]; then

--- a/src/main/resources/global/90-init-alfresco.sh
+++ b/src/main/resources/global/90-init-alfresco.sh
@@ -20,7 +20,8 @@ ${JAVA_HOME}/bin/java -jar /90-init-alfresco.jar "$CONFIG_FILE" "$TOMCAT_CONFIG_
 
 if [[ $SOLR_SSL == none ]] && [[ $ALFRESCO_VERSION != "5.0"* ]] && [[ $ALFRESCO_VERSION != "3"* ]] && [[ $ALFRESCO_VERSION != "4"* ]]; then
   #remove the SSL connector
-  sed -i '/<Connector port="\${TOMCAT_PORT_SSL}" URIEncoding="UTF-8" protocol="org.apache.coyote.http11.Http11Protocol" SSLEnabled="true"/,+5d' $TOMCAT_SERVER_FILE
+  apt-get update && apt-get install -y xmlstarlet #TODO: remove this when xml-starlet is no longer purged in docker-tomcat
+  xmlstarlet edit --inplace --delete "/Server/Service[@name='Catalina']/Connector[@SSLEnabled='true']" $TOMCAT_SERVER_FILE
 fi
 
 if [ -n "$CATALINA_HOME" ]; then


### PR DESCRIPTION
Quick-fix for the issue where we generate invalid XML because sed deletes too much.