### PR TITLE
Revert tika version

### DIFF
--- a/2repository/src/integrationTest/resources/docker-compose-alfresco-changed-ports.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-alfresco-changed-ports.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 
 services:
   alfresco:

--- a/2repository/src/integrationTest/resources/docker-compose-alfresco-minimal.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-alfresco-minimal.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 
 services:
  alfresco:

--- a/2repository/src/integrationTest/resources/docker-compose-alfresco.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-alfresco.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 
 services:
  alfresco:

--- a/2repository/src/integrationTest/resources/docker-compose-db.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-db.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 
 services:
 

--- a/2repository/src/integrationTest/resources/docker-compose-enterprise-only.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-enterprise-only.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 
 services:
   alfresco:

--- a/2repository/src/integrationTest/resources/docker-compose-share.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-share.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 
 services:
  share:

--- a/2repository/src/integrationTest/resources/docker-compose-solr-changed-ports.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-solr-changed-ports.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 
 services:
 

--- a/2repository/src/integrationTest/resources/docker-compose-solr.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-solr.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 
 services:
 

--- a/2repository/src/integrationTest/resources/docker-compose-transformers.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-transformers.yml
@@ -1,31 +1,44 @@
-version: '3'
+version: '3.2'
 
 services:
  alfresco-pdf-renderer:
    image: alfresco/alfresco-pdf-renderer:2.1.0
    environment:
      JAVA_OPTS: " -Xms256m -Xmx512m"
+   ports:
+     - target: 8090
+       mode: host
 
  libreoffice:
    image: alfresco/alfresco-libreoffice:2.1.0
    environment:
      JAVA_OPTS: " -Xms256m -Xmx512m"
+   ports:
+     - target: 8090
+       mode: host
 
  imagemagick:
    image: alfresco/alfresco-imagemagick:2.1.0
    environment:
      JAVA_OPTS: " -Xms256m -Xmx512m"
+   ports:
+     - target: 8090
+       mode: host
 
  # only works from Alfresco 6.1 on
  tika:
-   image: alfresco/alfresco-tika:2.1.0
+   image: alfresco/alfresco-tika:1.2
    environment:
      JAVA_OPTS: " -Xms256m -Xmx512m"
+   ports:
+     - target: 8090
+       mode: host
 
  # only works from Alfresco 6.1 on
- tika:
+ transform-misc:
    image: alfresco/alfresco-transform-misc:2.1.0
    environment:
      JAVA_OPTS: " -Xms256m -Xmx512m"
-
-
+   ports:
+     - target: 8090
+       mode: host


### PR DESCRIPTION
Newer version throws errors:

2020-06-19 11:18:16.118 ERROR 1 --- [nio-8090-exec-9] o.a.transformer.TransformController      : Request parameter 'sourceMimetype' is missing