### PR TITLE
Issue43 fix custom key stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,6 @@ Since in practice the [`remote jod converter`](https://github.com/xenit-eu/jodco
 
 Images can be customized further by using environment variables - see section Environment Variables.
 
-## TLS with Custom keystores
-
-It is advisable when enabling TLS to use newly create key- and truststores for keeping your keys and certificates. These stores should follow
-conventions as set out in the [alfresco documentation](https://docs.alfresco.com/search-enterprise/concepts/generate-keys-overview.html), but their location can be changed with the `DIR_KEYSTORE` environment variable.
-The system and application are provided access to these stores by adding a store-password.properties file for each respective store in the store 
-directory (see Alfresco documentation), and requires the environment variable `CUSTOM_KEYSTORES` to be set to true. 
 
 ## Environment variables
 
@@ -79,6 +73,20 @@ The alfresco-global.properties can be set via a generic mechanism by setting env
 A subset of the alfresco-global.properties have also dedicated environment variables e.g. SOLR_SSL. Generic variables take precedence.
 
 See also environment variables from lower layers: [`docker-openjdk`](https://github.com/xenit-eu/docker-openjdk) and [`docker-tomcat`](https://github.com/xenit-eu/docker-tomcat).
+
+* TLS with Custom keystores
+
+It is advisable when enabling TLS to use newly create key- and truststores for keeping your keys and certificates. These stores should follow
+conventions as set out in the [alfresco documentation](https://docs.alfresco.com/search-enterprise/concepts/generate-keys-overview.html), but their location can be changed with the `DIR_KEYSTORE` environment variable.
+The system and application are provided access to these stores by adding a store-password.properties file for each respective store in the store 
+directory (see Alfresco documentation), and requires the environment variable `CUSTOM_KEYSTORES` to be set to true. 
+
+* Log4j properties
+
+It is possible to set the loglevel for a given log4j logger by adding entries of the format`LOG4J_logger.fully.qualified.classname=LOGLEVEL`. The first step on the property path (`log4j`) will be added by the script.
+**note:**
+The current implementation will break generation of a custom image where the unexploded alfresco war is `COPY`ed into the image via Dockerfile ([See issue 32](https://github.com/xenit-eu/docker-alfresco/issues/32)).
+This issue can be worked around by `COPY`ing the exploded war, or by using the [alfresco-docker-gradle-plugin](https://github.com/xenit-eu/alfresco-docker-gradle-plugin).
 
 Environment variables:
 
@@ -114,6 +122,7 @@ Environment variables:
 | ENABLE_FTP                  | ftp.enabled                       |                                                              | false                                                        |  |
 | ENABLE_CLUSTERING           | alfresco.cluster.enabled          |                                                              | false                                                        |  |
 | GLOBAL_\<variable\>           | \<variable\>                        |                                                              |                                                              |  |
+| LOG4J_\<property-path\>     | N/A                               | N/A                                                          | N/A                                                          | Add the given property path and value to the alfresco log4j properties file. |
 
 
 ## Support & Collaboration

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Since in practice the [`remote jod converter`](https://github.com/xenit-eu/jodco
 
 Images can be customized further by using environment variables - see section Environment Variables.
 
+## TLS with Custom keystores
+
+It is advisable when enabling TLS to use newly create key- and truststores for keeping your keys and certificates. These stores should follow
+conventions as set out in the [alfresco documentation](https://docs.alfresco.com/search-enterprise/concepts/generate-keys-overview.html), but their location can be changed with the `DIR_KEYSTORE` environment variable.
+The system and application are provided access to these stores by adding a store-password.properties file for each respective store in the store 
+directory (see Alfresco documentation), and requires the environment variable `CUSTOM_KEYSTORES` to be set to true. 
+
 ## Environment variables
 
 There are several environment variables available to tweak the behaviour. While none of the variables are required, they may significantly aid you in using these images.
@@ -79,6 +86,7 @@ Environment variables:
 | --------------------------- | --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | --------------------------- |
 | DIR_ROOT                    | dir.root                          |                                                              | /opt/alfresco/alf_data                                                        |  |
 | DIR_KEYSTORE                | dir.keystore                      |                                                              | /opt/alfresco/keystore                                                        |  |
+| CUSTOM_KEYSTORES            | N/A                               |                                                              | false                                                        | Triggers whether during init the system will attempt to fill in password values into the tomcat connector definition from the store-password.properties files |
 | ALFRESCO_HOST               | alfresco.host                     |                                                              | alfresco                                                    |  |
 | ALFRESCO_PORT               | alfresco.port                     |                                                              | 8080                                                         |  |
 | ALFRESCO_PROTOCOL           | alfresco.protocol                 |                                                              | http                                                         |  |

--- a/docker-init-script/src/test/resources/eu/xenit/docker/alfresco/testSetCustomKeystores/ssl-keystore-passwords.properties
+++ b/docker-init-script/src/test/resources/eu/xenit/docker/alfresco/testSetCustomKeystores/ssl-keystore-passwords.properties
@@ -1,0 +1,4 @@
+aliases=ssl.alfresco.ca,ssl.repo
+keystore.password=keystore
+ssl.repo.password=RepoPass
+ssl.alfresco.ca.password=alfCaPass

--- a/docker-init-script/src/test/resources/eu/xenit/docker/alfresco/testSetCustomKeystores/ssl-truststore-passwords.properties
+++ b/docker-init-script/src/test/resources/eu/xenit/docker/alfresco/testSetCustomKeystores/ssl-truststore-passwords.properties
@@ -1,0 +1,5 @@
+aliases=alfresco.ca,ssl.repo.client,ssl.businessapi.client
+keystore.password=truststore
+alfresco.ca.password=alfCaPass
+ssl.repo.client=repoPass
+ssl.businessapi.client=busapiPass

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton
@@ -23,13 +23,13 @@ RUN	mkdir -p /opt/alfresco && \
             --insert '$connector' --type attr --name SSLEnabled --value true \
             --insert '$connector' --type attr --name maxThreads --value \$\{TOMCAT_MAX_THREADS\} \
             --insert '$connector' --type attr --name scheme --value https \
-            --insert '$connector' --type attr --name keystoreFile --value /opt/alfresco/keystore/ssl.keystore \
-            --insert '$connector' --type attr --name keystorePass --value kT9X6oe68t \
+            --insert '$connector' --type attr --name keystoreFile --value \$\{TOMCAT_SSL_KEYSTORE\} \
+            --insert '$connector' --type attr --name keystorePass --value \$\{TOMCAT_SSL_KEYSTORE_PASSWORD\} \
             --insert '$connector' --type attr --name keystoreType --value JCEKS \
             --insert '$connector' --type attr --name secure --value true \
             --insert '$connector' --type attr --name connectionTimeout --value 240000 \
-            --insert '$connector' --type attr --name truststoreFile --value /opt/alfresco/keystore/ssl.truststore \
-            --insert '$connector' --type attr --name truststorePass --value kT9X6oe68t \
+            --insert '$connector' --type attr --name truststoreFile --value \$\{TOMCAT_SSL_TRUSTSTORE\} \
+            --insert '$connector' --type attr --name truststorePass --value \$\{TOMCAT_SSL_TRUSTSTORE_PASSWORD\} \
             --insert '$connector' --type attr --name truststoreType --value JCEKS \
             --insert '$connector' --type attr --name clientAuth --value want \
             --insert '$connector' --type attr --name sslProtocol --value TLS \

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
@@ -48,13 +48,13 @@ RUN	mkdir -p /opt/alfresco && \
             --insert '$connector' --type attr --name SSLEnabled --value true \
             --insert '$connector' --type attr --name maxThreads --value \$\{TOMCAT_MAX_THREADS\} \
             --insert '$connector' --type attr --name scheme --value https \
-            --insert '$connector' --type attr --name keystoreFile --value /opt/alfresco/keystore/ssl.keystore \
-            --insert '$connector' --type attr --name keystorePass --value kT9X6oe68t \
+            --insert '$connector' --type attr --name keystoreFile --value \$\{TOMCAT_SSL_KEYSTORE\} \
+            --insert '$connector' --type attr --name keystorePass --value \$\{TOMCAT_SSL_KEYSTORE_PASSWORD\} \
             --insert '$connector' --type attr --name keystoreType --value JCEKS \
             --insert '$connector' --type attr --name secure --value true \
             --insert '$connector' --type attr --name connectionTimeout --value 240000 \
-            --insert '$connector' --type attr --name truststoreFile --value /opt/alfresco/keystore/ssl.truststore \
-            --insert '$connector' --type attr --name truststorePass --value kT9X6oe68t \
+            --insert '$connector' --type attr --name truststoreFile --value \$\{TOMCAT_SSL_TRUSTSTORE\} \
+            --insert '$connector' --type attr --name truststorePass --value \$\{TOMCAT_SSL_TRUSTSTORE_PASSWORD\} \
             --insert '$connector' --type attr --name truststoreType --value JCEKS \
             --insert '$connector' --type attr --name clientAuth --value want \
             --insert '$connector' --type attr --name sslProtocol --value TLS \


### PR DESCRIPTION
# Fix for GH Issue 43 / Jira ticket DOCKER-341:

## Goal
Improve integration for custom keystores.

## Usage
The DIR_KEYSTORE variable continues to be used to point to the directory containing all keystores and their paasword-property files.
The CUSTOM_KEYSTORES variable denotes the usage of files/passwords different from the preconfigured ones.
Keystores should adhere to the naming convention set out by alfresco (see alfresco docs/github:alfresco-ssl-generator).

## Implementation details

This implementation has the relevant values in the server.xml file replaced by property references, and sets the values of those properties in the 90-init-alfresco script.
This method was chosen over an implementation where the values were directly written into the xml file due to DOCKER-339.
The file location values are a composition of the DIR_KEYSTORE value and the convential store names (hence adherence to the alfresco docs).
The password values are retrieved from the password.properties files based on whether CUSTOM_KEYSTORES is set to true and the value generated from DIR_KEYSTORE. 
The script is written such that the old hardcoded values are used as defaults if the variables described above are not set for changes.