### PR TITLE
DOCKER-311 Raise requirements for chown in 90-init-alfresco.sh

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [DOCKER-312] Start a release procedure: add Xenit version to the images tags
 	
 ### Changed
+* [DOCKER-311] Change requirements for `chown` in `90-init-alfresco.sh` to prevent costly chown operations
 * [DOCKER-278] Move java specific variables (jmx, debug, memory settings) to java layer
 * [DOCKER-236] Separate out share: see https://github.com/xenit-eu/docker-share
 * [DOCKER-255] Continue to build some legacy images, with both Alfresco and Share inside

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Environment variables:
 | DB_URL                      | db.url                            |                                                              | jdbc:postgresql://postgresql:5432/alfresco                   |  |
 | DB_QUERY                    | db.pool.validate.query            |                                                              | select 1                                                     |  |
 | INDEX                       | index.subsystem.name              |                                                              | solr for alfresco 4 <br>solr4 for alfresco 5<br>solr6 for alfresco >=5.2 |  |
-| SOLR_HOST             | solr.host                         |                                                              | solr                                                         |  |
+| SOLR_HOST                   | solr.host                         |                                                              | solr                                                         |  |
 | SOLR_PORT                   | solr.port                         |                                                              | 8080                                                         |  |
 | SOLR_PORT_SSL               | solr.port.ssl                     |                                                              | 8443                                                         |  |
 | DYNAMIC_SHARD_REGISTRATION  | solr.useDynamicShardRegistration  |                                                              | false                                                        |  |
@@ -121,8 +121,9 @@ Environment variables:
 | ENABLE_CIFS                 | cifs.enabled                      |                                                              | false                                                        |  |
 | ENABLE_FTP                  | ftp.enabled                       |                                                              | false                                                        |  |
 | ENABLE_CLUSTERING           | alfresco.cluster.enabled          |                                                              | false                                                        |  |
-| GLOBAL_\<variable\>           | \<variable\>                        |                                                              |                                                              |  |
+| GLOBAL_\<variable\>         | \<variable\>                        |                                                              |                                                              |  |
 | LOG4J_\<property-path\>     | N/A                               | N/A                                                          | N/A                                                          | Add the given property path and value to the alfresco log4j properties file. |
+| CHOWN_CUTOFF                | N/A                               | N/A                                                          | 10 000                                                       | In case a `chown` on `alf_data` or `${CATALINA_HOME}/temp` is required, determine the maximum number of items alf_data can contain to proceed automatically with the chown. Will error with code 64 or 65 if exceeded. |
 
 
 ## Support & Collaboration

--- a/README.md
+++ b/README.md
@@ -123,8 +123,6 @@ Environment variables:
 | ENABLE_CLUSTERING           | alfresco.cluster.enabled          |                                                              | false                                                        |  |
 | GLOBAL_\<variable\>         | \<variable\>                      |                                                              |                                                              |  |
 | LOG4J_\<property-path\>     | N/A                               | N/A                                                          | N/A                                                          | Add the given property path and value to the alfresco log4j properties file. |
-| CHOWN_CUTOFF                | N/A                               | N/A                                                          | 10 000                                                       | In case a `chown` on `alf_data` or `${CATALINA_HOME}/temp` is required, determine the maximum number of items alf_data can contain to proceed automatically with the chown. Will error with code 64 or 65 if exceeded. |
-| ENABLE_CHOWNCUTOFF          | N/A                               | N/A                                                          | true                                                         | Toggles whether `90-init-alfresco.sh` will test the viability of a possible chown on `alf_data` or `${CATALINA_HOME}/temp` |
 
 
 ## Support & Collaboration

--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ Environment variables:
 | ENABLE_CIFS                 | cifs.enabled                      |                                                              | false                                                        |  |
 | ENABLE_FTP                  | ftp.enabled                       |                                                              | false                                                        |  |
 | ENABLE_CLUSTERING           | alfresco.cluster.enabled          |                                                              | false                                                        |  |
-| GLOBAL_\<variable\>         | \<variable\>                        |                                                              |                                                              |  |
+| GLOBAL_\<variable\>         | \<variable\>                      |                                                              |                                                              |  |
 | LOG4J_\<property-path\>     | N/A                               | N/A                                                          | N/A                                                          | Add the given property path and value to the alfresco log4j properties file. |
 | CHOWN_CUTOFF                | N/A                               | N/A                                                          | 10 000                                                       | In case a `chown` on `alf_data` or `${CATALINA_HOME}/temp` is required, determine the maximum number of items alf_data can contain to proceed automatically with the chown. Will error with code 64 or 65 if exceeded. |
+| ENABLE_CHOWNCUTOFF          | N/A                               | N/A                                                          | true                                                         | Toggles whether `90-init-alfresco.sh` will test the viability of a possible chown on `alf_data` or `${CATALINA_HOME}/temp` |
 
 
 ## Support & Collaboration

--- a/src/main/resources/global/90-init-alfresco.sh
+++ b/src/main/resources/global/90-init-alfresco.sh
@@ -33,7 +33,7 @@ if [ -n "$CATALINA_HOME" ]; then
   # -> else if not exists, chown only alf_data
   if [[ -e /opt/alfresco/alf_data/contentstore && -e /opt/alfresco/alf_data/contentstore.deleted ]]; then
     if [[ ($(stat -c %U /opt/alfresco/alf_data/contentstore) != "$user" && $(stat -c %a /opt/alfresco/alf_data/contentstore) -lt 766)\
-     && ($(stat -c %U /opt/alfresco/alf_data/contentstore.deleted) != "$user" && $(stat -c %a /opt/alfresco/alf_data/contentstore.deleted) -lt 766) ]]; then
+     || ($(stat -c %U /opt/alfresco/alf_data/contentstore.deleted) != "$user" && $(stat -c %a /opt/alfresco/alf_data/contentstore.deleted) -lt 766) ]]; then
       # custom exit code for debug to this script
       echo "Contentstores exists within /opt/alfresco/alf_data , but do not have correct ownership/permission to run alfresco. Exiting with code 64."
       exit 64

--- a/src/main/resources/global/90-init-alfresco.sh
+++ b/src/main/resources/global/90-init-alfresco.sh
@@ -30,13 +30,14 @@ if [ -n "$CATALINA_HOME" ]; then
   # -> if dir exists, check if the permissions are incorrect
   # --> if permissions are incorrect, exit with error code
   # -> else if not exists, chown only alf_data
-  if [[ -e /opt/alfresco/alf_data/contentstore \
-   && ($(stat -c %U /opt/alfresco/alf_data) != "$user" && $(stat -c %a /opt/alfresco/alf_data) -lt 766) ]]; then
-     # custom exit code for debug to this script
-     echo "Contentstore exists within /opt/alfresco/alf_data , but directory does not have correct ownership/permission to run alfresco. Exiting with code 64."
-     exit 64
+  if [[ -e /opt/alfresco/alf_data/contentstore && -e /opt/alfresco/alf_data/contentstore.deleted\
+   && ($(stat -c %U /opt/alfresco/alf_data/contentstore) != "$user" && $(stat -c %a /opt/alfresco/alf_data/contentstore) -lt 766)\
+   && ($(stat -c %U /opt/alfresco/alf_data/contentstore.deleted) != "$user" && $(stat -c %a /opt/alfresco/alf_data/contentstore.deleted) -lt 766) ]]; then
+    # custom exit code for debug to this script
+    echo "Contentstores exists within /opt/alfresco/alf_data , but do not have correct ownership/permission to run alfresco. Exiting with code 64."
+    exit 64
   else
-    echo "No contentstore in alf_data, chowning directory to tomcat user."
+    echo "No contentstore in alf_data ; assuming dev/test environment, chowning alf_data to tomcat user."
     chown $user:$user /opt/alfresco/alf_data
   fi
 

--- a/src/main/resources/global/90-init-alfresco.sh
+++ b/src/main/resources/global/90-init-alfresco.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # we should get env ${CATALINA_HOME} from upstream container docker
-set -exv
+set -e
 
 echo "Alfresco init start"
 

--- a/src/main/resources/global/90-init-alfresco.sh
+++ b/src/main/resources/global/90-init-alfresco.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # we should get env ${CATALINA_HOME} from upstream container docker
-set -e
+set -exv
 
 echo "Alfresco init start"
 
@@ -11,7 +11,7 @@ export DB_NAME=${DB_NAME:-'alfresco'}
 export SOLR_SSL=${SOLR_SSL:-'https'}
 export JAVA_OPTS
 
-ENABLE_CHOWNCUTOFF=${ENABLE_CHOWNCUTOFF:-true}
+ENABLE_CHOWNCUTOFF=${ENABLE_CHOWNCUTOFF:-'true'}
 CHOWNCUTOFF=${CHOWN_CUTOFF:-10000}
 
 CONFIG_FILE=${CONFIG_FILE:-${CATALINA_HOME}'/shared/classes/alfresco-global.properties'}
@@ -30,7 +30,7 @@ if [ -n "$CATALINA_HOME" ]; then
 
   user="tomcat"
   if [[ ($(stat -c %U /opt/alfresco/alf_data) != "$user" && $(stat -c %a /opt/alfresco/alf_data) -lt 766) ]]; then
-    if [[ ${ENABLE_CHOWNCUTOFF} ]]; then
+    if [[ "$ENABLE_CHOWNCUTOFF" == 'true' ]]; then
         # check if number of files exceeds cutoff value to prevent longrunning chown process.
         find /opt/alfresco/alf_data | head -n $CHOWNCUTOFF > /dev/null
         # * pipestatus will be 0 if the above find ended before head ended.
@@ -48,7 +48,7 @@ if [ -n "$CATALINA_HOME" ]; then
     fi
   fi
   if [[ ($(stat -c %U "$CATALINA_HOME/temp") != "$user" && $(stat -c %a "$CATALINA_HOME/temp") -lt 766) ]]; then
-    if [[ ${ENABLE_CHOWNCUTOFF} ]]; then
+    if [[ "$ENABLE_CHOWNCUTOFF" == 'true' ]]; then
         find "$CATALINA_HOME/temp" | head -n $CHOWNCUTOFF > /dev/null
         if [[ ${PIPESTATUS[0]} -eq 0 ]]; then
           chown -R $user:$user "$CATALINA_HOME"/temp

--- a/src/main/resources/global/90-init-alfresco.sh
+++ b/src/main/resources/global/90-init-alfresco.sh
@@ -11,6 +11,7 @@ export DB_NAME=${DB_NAME:-'alfresco'}
 export SOLR_SSL=${SOLR_SSL:-'https'}
 export JAVA_OPTS
 
+ENABLE_CHOWNCUTOFF=${ENABLE_CHOWNCUTOFF:-true}
 CHOWNCUTOFF=${CHOWN_CUTOFF:-10000}
 
 CONFIG_FILE=${CONFIG_FILE:-${CATALINA_HOME}'/shared/classes/alfresco-global.properties'}
@@ -29,25 +30,33 @@ if [ -n "$CATALINA_HOME" ]; then
 
   user="tomcat"
   if [[ ($(stat -c %U /opt/alfresco/alf_data) != "$user" && $(stat -c %a /opt/alfresco/alf_data) -lt 766) ]]; then
-    # check if number of files exceeds cutoff value to prevent longrunning chown process.
-    find /opt/alfresco/alf_data | head -n $CHOWNCUTOFF > /dev/null
-    # * pipestatus will be 0 if the above find ended before head ended.
-    # * pipestatus will be 141 if the above head ends before find -which implies there are more than CHOWNCUTOFF files,
-    #   which means the following chown would be expensive in time.
-    #   sigpipe will cause the find to end.
-    if [[ ${PIPESTATUS[0]} -eq 0 ]]; then
-      chown -R $user:$user /opt/alfresco/alf_data
+    if [[ ${ENABLE_CHOWNCUTOFF} ]]; then
+        # check if number of files exceeds cutoff value to prevent longrunning chown process.
+        find /opt/alfresco/alf_data | head -n $CHOWNCUTOFF > /dev/null
+        # * pipestatus will be 0 if the above find ended before head ended.
+        # * pipestatus will be 141 if the above head ends before find -which implies there are more than CHOWNCUTOFF files,
+        #   which means the following chown would be expensive in time.
+        #   sigpipe will cause the find to end.
+        if [[ ${PIPESTATUS[0]} -eq 0 ]]; then
+          chown -R $user:$user /opt/alfresco/alf_data
+        else
+          # custom exit code for debug to this script
+          exit 64
+        fi
     else
-      # custom exit code for debug to this script
-      exit 64
+        chown -R $user:$user /opt/alfresco/alf_data
     fi
   fi
   if [[ ($(stat -c %U "$CATALINA_HOME/temp") != "$user" && $(stat -c %a "$CATALINA_HOME/temp") -lt 766) ]]; then
-    find "$CATALINA_HOME/temp" | head -n $CHOWNCUTOFF > /dev/null
-    if [[ ${PIPESTATUS[0]} -eq 0 ]]; then
-      chown -R $user:$user "$CATALINA_HOME"/temp
+    if [[ ${ENABLE_CHOWNCUTOFF} ]]; then
+        find "$CATALINA_HOME/temp" | head -n $CHOWNCUTOFF > /dev/null
+        if [[ ${PIPESTATUS[0]} -eq 0 ]]; then
+          chown -R $user:$user "$CATALINA_HOME"/temp
+        else
+          exit 65
+        fi
     else
-      exit 65
+        chown -R $user:$user "$CATALINA_HOME"/temp
     fi
   fi
 

--- a/src/main/resources/global/90-init-alfresco.sh
+++ b/src/main/resources/global/90-init-alfresco.sh
@@ -11,9 +11,6 @@ export DB_NAME=${DB_NAME:-'alfresco'}
 export SOLR_SSL=${SOLR_SSL:-'https'}
 export JAVA_OPTS
 
-ENABLE_CHOWNCUTOFF=${ENABLE_CHOWNCUTOFF:-'true'}
-CHOWNCUTOFF=${CHOWN_CUTOFF:-10000}
-
 CONFIG_FILE=${CONFIG_FILE:-${CATALINA_HOME}'/shared/classes/alfresco-global.properties'}
 LOG4J_CONFIG_FILE=${LOG4J_CONFIG_FILE:-${CATALINA_HOME}'/webapps/alfresco/WEB-INF/classes/alfresco/extension/dev-log4j.properties'}
 TOMCAT_CONFIG_FILE=${CATALINA_HOME}'/bin/setenv.sh'
@@ -29,35 +26,22 @@ fi
 if [ -n "$CATALINA_HOME" ]; then
 
   user="tomcat"
-  if [[ ($(stat -c %U /opt/alfresco/alf_data) != "$user" && $(stat -c %a /opt/alfresco/alf_data) -lt 766) ]]; then
-    if [[ "$ENABLE_CHOWNCUTOFF" == 'true' ]]; then
-        # check if number of files exceeds cutoff value to prevent longrunning chown process.
-        find /opt/alfresco/alf_data | head -n $CHOWNCUTOFF > /dev/null
-        # * pipestatus will be 0 if the above find ended before head ended.
-        # * pipestatus will be 141 if the above head ends before find -which implies there are more than CHOWNCUTOFF files,
-        #   which means the following chown would be expensive in time.
-        #   sigpipe will cause the find to end.
-        if [[ ${PIPESTATUS[0]} -eq 0 ]]; then
-          chown -R $user:$user /opt/alfresco/alf_data
-        else
-          # custom exit code for debug to this script
-          exit 64
-        fi
-    else
-        chown -R $user:$user /opt/alfresco/alf_data
-    fi
+  # Check existence of alf_data/contentstore
+  # -> if dir exists, check if the permissions are incorrect
+  # --> if permissions are incorrect, exit with error code
+  # -> else if not exists, chown only alf_data
+  if [[ -e /opt/alfresco/alf_data/contentstore \
+   && ($(stat -c %U /opt/alfresco/alf_data) != "$user" && $(stat -c %a /opt/alfresco/alf_data) -lt 766) ]]; then
+     # custom exit code for debug to this script
+     echo "Contentstore exists within /opt/alfresco/alf_data , but directory does not have correct ownership/permission to run alfresco. Exiting with code 64."
+     exit 64
+  else
+    echo "No contentstore in alf_data, chowning directory to tomcat user."
+    chown $user:$user /opt/alfresco/alf_data
   fi
-  if [[ ($(stat -c %U "$CATALINA_HOME/temp") != "$user" && $(stat -c %a "$CATALINA_HOME/temp") -lt 766) ]]; then
-    if [[ "$ENABLE_CHOWNCUTOFF" == 'true' ]]; then
-        find "$CATALINA_HOME/temp" | head -n $CHOWNCUTOFF > /dev/null
-        if [[ ${PIPESTATUS[0]} -eq 0 ]]; then
-          chown -R $user:$user "$CATALINA_HOME"/temp
-        else
-          exit 65
-        fi
-    else
-        chown -R $user:$user "$CATALINA_HOME"/temp
-    fi
+
+  if [[ $(stat -c %U "$CATALINA_HOME/temp") != "$user" ]]; then
+    chown -R $user:$user "$CATALINA_HOME"/temp
   fi
 
 fi

--- a/src/main/resources/global/90-init-alfresco.sh
+++ b/src/main/resources/global/90-init-alfresco.sh
@@ -29,13 +29,15 @@ if [ -n "$CATALINA_HOME" ]; then
   # Check existence of alf_data/contentstore
   # -> if dir exists, check if the permissions are incorrect
   # --> if permissions are incorrect, exit with error code
+  # --> else if correct, do nothing
   # -> else if not exists, chown only alf_data
-  if [[ -e /opt/alfresco/alf_data/contentstore && -e /opt/alfresco/alf_data/contentstore.deleted\
-   && ($(stat -c %U /opt/alfresco/alf_data/contentstore) != "$user" && $(stat -c %a /opt/alfresco/alf_data/contentstore) -lt 766)\
-   && ($(stat -c %U /opt/alfresco/alf_data/contentstore.deleted) != "$user" && $(stat -c %a /opt/alfresco/alf_data/contentstore.deleted) -lt 766) ]]; then
-    # custom exit code for debug to this script
-    echo "Contentstores exists within /opt/alfresco/alf_data , but do not have correct ownership/permission to run alfresco. Exiting with code 64."
-    exit 64
+  if [[ -e /opt/alfresco/alf_data/contentstore && -e /opt/alfresco/alf_data/contentstore.deleted ]]; then
+    if [[ ($(stat -c %U /opt/alfresco/alf_data/contentstore) != "$user" && $(stat -c %a /opt/alfresco/alf_data/contentstore) -lt 766)\
+     && ($(stat -c %U /opt/alfresco/alf_data/contentstore.deleted) != "$user" && $(stat -c %a /opt/alfresco/alf_data/contentstore.deleted) -lt 766) ]]; then
+      # custom exit code for debug to this script
+      echo "Contentstores exists within /opt/alfresco/alf_data , but do not have correct ownership/permission to run alfresco. Exiting with code 64."
+      exit 64
+    fi
   else
     echo "No contentstore in alf_data ; assuming dev/test environment, chowning alf_data to tomcat user."
     chown $user:$user /opt/alfresco/alf_data


### PR DESCRIPTION
Recent experience has pointed out that mounting a large, existing
alf_data with incorrect permissions/ownership resulted in a very
extensive chown. The prefered solution would have been to fix the issue
through changes to the users/groups on the host, or even to the user
set in the image/container.

The proposed change will check 
1. if contentstores already exists within alf_data
This is an okay indicator whether the system is a fresh install or a pre-existing system
2. check if the permissions/ownership is correct for those contentstores
This is checks if the requirements for proper functioning of alfresco

if both checks are true, no operation is executed
if 1 is true, but 2 is false, the script exits with custom error code
if 1 is false, the alf_data dir is chowned

This change will prevent auto-executing costly operations on existing systems, allowing an operator to decide on the best course of action; while also maintaining some flexibility for non-critical cases such as development.