### PR TITLE
Fix build of Alfresco enterprise images on Xenit's build server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,20 @@ subprojects {
 
     repositories {
         mavenCentral()
-        jcenter()
         maven {
             url 'https://artifacts.alfresco.com/nexus/content/repositories/public/'
+        }
+        // This private repository provides Xenit with Alfresco enterprise artefacts.
+        // External developers should replace it with their own library repository.
+        if(project.hasProperty('eu.xenit.artifactory.username') && project.hasProperty('eu.xenit.artifactory.password')) {
+            maven {
+                name 'Xenit artifactory release local'
+                url 'https://artifactory.xenit.eu/artifactory/libs-release'
+                credentials {
+                    username property("eu.xenit.artifactory.username")
+                    password property("eu.xenit.artifactory.password")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Hello @anghelutar  ,

Due to the cleanup of init.gradle on Xenit's build server, the Alfresco enterprise images don't build anymore.

With the updates on docker-openjdk and docker-tomcat, I think it is a good idea to rebuild the docker-alfresco images so they contain the last openjdk and tomcat updates.

Question regarding all the branches in this project
Can I clean up (delete) all the branches that have been merged or closed?

Kind regards,
Koen