### PR TITLE
Update PostgreSQL JDBC driver to 42.2.18

### DIFF
--- a/2repository/4.2/community-4.2.f/overload.gradle
+++ b/2repository/4.2/community-4.2.f/overload.gradle
@@ -16,5 +16,5 @@ ext {
 dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco:4.2.f@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212.jre7')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18.jre7')
 }

--- a/2repository/4.2/enterprise-4.2.8/overload.gradle
+++ b/2repository/4.2/enterprise-4.2.8/overload.gradle
@@ -16,5 +16,5 @@ ext {
 dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco:4.2.8@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212.jre7')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18.jre7')
 }

--- a/2repository/5.0/community-5.0.d/overload.gradle
+++ b/2repository/5.0/community-5.0.d/overload.gradle
@@ -15,5 +15,5 @@ ext {
 dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco:5.0.d@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }

--- a/2repository/5.0/enterprise-5.0.4/overload.gradle
+++ b/2repository/5.0/enterprise-5.0.4/overload.gradle
@@ -15,5 +15,5 @@ ext {
 dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco-enterprise:5.0.4@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }

--- a/2repository/5.1/community-5.1.e/overload.gradle
+++ b/2repository/5.1/community-5.1.e/overload.gradle
@@ -15,5 +15,5 @@ ext {
 dependencies {
     baseAlfrescoWar "org.alfresco:alfresco:5.1.e@war"
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }

--- a/2repository/5.1/ent-rename-for-build-5.1.1/overload.gradle
+++ b/2repository/5.1/ent-rename-for-build-5.1.1/overload.gradle
@@ -15,5 +15,5 @@ ext {
 dependencies {
     baseAlfrescoWar "org.alfresco:alfresco-enterprise:5.1.1@war"
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }

--- a/2repository/5.1/ent-rename-for-build-5.1.4/overload.gradle
+++ b/2repository/5.1/ent-rename-for-build-5.1.4/overload.gradle
@@ -17,5 +17,5 @@ ext {
 dependencies {
     baseAlfrescoWar "org.alfresco:alfresco-enterprise:5.1.4.1@war"
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }

--- a/2repository/5.1/enterprise-5.1.5/overload.gradle
+++ b/2repository/5.1/enterprise-5.1.5/overload.gradle
@@ -15,5 +15,5 @@ ext {
 dependencies {
     baseAlfrescoWar "org.alfresco:alfresco-enterprise:5.1.5@war"
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }

--- a/2repository/5.2/community-5.2.g/overload.gradle
+++ b/2repository/5.2/community-5.2.g/overload.gradle
@@ -17,5 +17,5 @@ dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco-platform:5.2.g@war'
 
     sharedBin(group: 'org.alfresco', name: 'alfresco-pdf-renderer', version: '1.1', classifier: 'linux', ext: 'tgz')
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }

--- a/2repository/5.2/ent-rename-for-build-5.2.0/overload.gradle
+++ b/2repository/5.2/ent-rename-for-build-5.2.0/overload.gradle
@@ -16,5 +16,5 @@ dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco-enterprise:5.2.0@war'
 
     sharedBin(group: 'org.alfresco', name: 'alfresco-pdf-renderer', version: '1.1', classifier: 'linux', ext: 'tgz')
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }

--- a/2repository/5.2/ent-rename-for-build-5.2.2/overload.gradle
+++ b/2repository/5.2/ent-rename-for-build-5.2.2/overload.gradle
@@ -16,6 +16,6 @@ dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco-enterprise:5.2.2@war'
 
     sharedBin(group: 'org.alfresco', name: 'alfresco-pdf-renderer', version: '1.1', classifier: 'linux', ext: 'tgz')
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }
 

--- a/2repository/5.2/ent-rename-for-build-5.2.3/overload.gradle
+++ b/2repository/5.2/ent-rename-for-build-5.2.3/overload.gradle
@@ -16,6 +16,6 @@ dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco-enterprise:5.2.3@war'
 
     sharedBin(group: 'org.alfresco', name: 'alfresco-pdf-renderer', version: '1.1', classifier: 'linux', ext: 'tgz')
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }
 

--- a/2repository/5.2/ent-rename-for-build-5.2.4/overload.gradle
+++ b/2repository/5.2/ent-rename-for-build-5.2.4/overload.gradle
@@ -16,6 +16,6 @@ dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco-enterprise:5.2.4@war'
 
     sharedBin(group: 'org.alfresco', name: 'alfresco-pdf-renderer', version: '1.1', classifier: 'linux', ext: 'tgz')
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }
 

--- a/2repository/5.2/ent-rename-for-build-5.2.5/overload.gradle
+++ b/2repository/5.2/ent-rename-for-build-5.2.5/overload.gradle
@@ -16,6 +16,6 @@ dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco-enterprise:5.2.5@war'
 
     sharedBin(group: 'org.alfresco', name: 'alfresco-pdf-renderer', version: '1.1', classifier: 'linux', ext: 'tgz')
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }
 

--- a/2repository/5.2/ent-rename-for-build-5.2.6/overload.gradle
+++ b/2repository/5.2/ent-rename-for-build-5.2.6/overload.gradle
@@ -16,6 +16,6 @@ dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco-enterprise:5.2.6@war'
 
     sharedBin(group: 'org.alfresco', name: 'alfresco-pdf-renderer', version: '1.1', classifier: 'linux', ext: 'tgz')
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }
 

--- a/2repository/5.2/enterprise-5.2.7/overload.gradle
+++ b/2repository/5.2/enterprise-5.2.7/overload.gradle
@@ -17,6 +17,6 @@ dependencies {
     baseAlfrescoWar 'org.alfresco:alfresco-enterprise:5.2.7.3@war'
 
     sharedBin(group: 'org.alfresco', name: 'alfresco-pdf-renderer', version: '1.1', classifier: 'linux', ext: 'tgz')
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }
 

--- a/2repository/6.0/community-6.0.7-ga/overload.gradle
+++ b/2repository/6.0/community-6.0.7-ga/overload.gradle
@@ -16,5 +16,5 @@ dependencies {
     alfrescoAmp 'org.alfresco:alfresco-share-services:6.0.c@amp'
     baseAlfrescoWar 'org.alfresco:content-services-community:6.0.7-ga@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }

--- a/2repository/6.0/ent-rename-for-build-6.0.0/overload.gradle
+++ b/2repository/6.0/ent-rename-for-build-6.0.0/overload.gradle
@@ -16,6 +16,6 @@ dependencies {
     alfrescoAmp 'org.alfresco:alfresco-share-services:6.0@amp'
     baseAlfrescoWar 'org.alfresco:content-services:6.0.0@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }
 

--- a/2repository/6.0/enterprise-6.0.1/overload.gradle
+++ b/2repository/6.0/enterprise-6.0.1/overload.gradle
@@ -17,6 +17,6 @@ dependencies {
     alfrescoAmp 'org.alfresco:alfresco-share-services:6.0.1.1@amp'
     baseAlfrescoWar 'org.alfresco:content-services:6.0.1.3@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }
 

--- a/2repository/6.1/community-6.1.2-ga/overload.gradle
+++ b/2repository/6.1/community-6.1.2-ga/overload.gradle
@@ -16,5 +16,5 @@ dependencies {
     alfrescoAmp 'org.alfresco:alfresco-share-services:6.1.0.2@amp'
     baseAlfrescoWar 'org.alfresco:content-services-community:6.1.2-ga@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }

--- a/2repository/6.1/enterprise-6.1.1/overload.gradle
+++ b/2repository/6.1/enterprise-6.1.1/overload.gradle
@@ -17,6 +17,6 @@ dependencies {
     alfrescoAmp 'org.alfresco:alfresco-share-services:6.1.1.1@amp'    
     baseAlfrescoWar 'org.alfresco:content-services:6.1.1.3@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }
 

--- a/2repository/6.2/community-6.2.0-ga/overload.gradle
+++ b/2repository/6.2/community-6.2.0-ga/overload.gradle
@@ -16,5 +16,5 @@ dependencies {
     alfrescoAmp 'org.alfresco:alfresco-share-services:6.2.0@amp'
     baseAlfrescoWar 'org.alfresco:content-services-community:6.2.0-ga@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }

--- a/2repository/6.2/ent-rename-for-build-6.2.0/overload.gradle
+++ b/2repository/6.2/ent-rename-for-build-6.2.0/overload.gradle
@@ -16,6 +16,6 @@ dependencies {
     alfrescoAmp 'org.alfresco:alfresco-share-services:6.2.0@amp'
     baseAlfrescoWar 'org.alfresco:content-services:6.2.0@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }
 

--- a/2repository/6.2/enterprise-6.2.1/overload.gradle
+++ b/2repository/6.2/enterprise-6.2.1/overload.gradle
@@ -16,6 +16,6 @@ dependencies {
     alfrescoAmp 'org.alfresco:alfresco-share-services:6.2.0@amp'
     baseAlfrescoWar 'org.alfresco:content-services:6.2.1@war'
 
-    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '9.4.1212')
+    sharedLib(group: 'org.postgresql', name: 'postgresql', version: '42.2.18')
 }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+## 2020-11.0
+### Changed
+* [2020-11-15] [PR #52](https://github.com/xenit-eu/docker-alfresco/pull/52) Update PostgreSQL JDBC driver to 42.2.18
 
 ## Unreleased
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,9 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## 2020-11.0
+## 2020-11.0 (2020-11-15)
 ### Changed
-* [2020-11-15] [PR #52](https://github.com/xenit-eu/docker-alfresco/pull/52) Update PostgreSQL JDBC driver to 42.2.18
+* [PR #52](https://github.com/xenit-eu/docker-alfresco/pull/52) Update PostgreSQL JDBC driver to 42.2.18
 
 ## Unreleased
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-xenitVersion=1.0.1-SNAPSHOT
+xenitVersion=2020-11.0


### PR DESCRIPTION
Hello @anghelutar and @tgeens,

The Alfresco images are still including an old version of the PostgreSQL JDBC driver (v9.4.1212 released on 2016-11-02; latest v9.4 version).

I believe the Alfresco image, should at least include as minimal version the PostgreSQL JDBC driver version mentioned in the [Supported Platform for Alfresco Content Services documentation](https://www.alfresco.com/services/subscription/supported-platforms).

Minimal PostgreSQL JDB driver versions:
- Alfresco 6.2: 42.2.1, 42.2.6, 42.2.14
- Alfresco 6.1: 42.2.1, 42.2.6
- Alfresco 6.0: 42.2.1
- Alfresco 5.2: 9.4.1211, 42.2.12
- Alfresco 5.1: 9.4.1201
- Alfresco 5.0: 9.3.1102
- Alfresco 4.2: 9.0.802

I took the liberty to upgrade the PostgreSQL JDBC driver for all Alfresco versions, since the current version (42.2.18) supports PostgreSQL 8.2 or newer and Java 6 or newer (see [documentation](https://jdbc.postgresql.org/download.html)).

Kind regards,
Koen