### PR TITLE
Fix publishing of enterprise legacy images

### DIFF
--- a/3legacy/build.gradle
+++ b/3legacy/build.gradle
@@ -35,7 +35,12 @@ chown -R tomcat:tomcat "${CATALINA_HOME}/shared/classes/alfresco/web-extension/"
         }
     }
 
+    // nested configurations do not get the DOCKER_IMAGE
     buildDockerImage {
         pull = false
+        doLast {
+            if (project.hasProperty('testsChangedPorts') && project.testsChangedPorts)
+                dockerCompose.changedPorts.environment.put 'DOCKER_IMAGE', getImageId().get()
+        }
     }
 }


### PR DESCRIPTION
Hello @vierbergenlars ,

Publishing of the enterprise legacy images fail because there doesn't seem to be a legacy docker image available to publish.
Seen build #105 on Xenit's build server.

This is a first attempt to fix, since I am not able to really verify.
I don't know whether this is the correct change to make. Could you have a look?

For your comments.

Kind regards,
Koen