### PR TITLE
DOCKER-376: support for limiting the number of days application log files are being kept.

### DIFF
--- a/2repository/src/integrationTest/resources/docker-compose-alfresco-minimal.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-alfresco-minimal.yml
@@ -12,5 +12,3 @@ services:
    - SOLR_HOST=solr
    - GLOBAL_legacy.transform.service.enabled=false
    - GLOBAL_local.transform.service.enabled=false
-   - APPLICATIONLOG_MAXDAYS=1
-

--- a/2repository/src/integrationTest/resources/docker-compose-alfresco-minimal.yml
+++ b/2repository/src/integrationTest/resources/docker-compose-alfresco-minimal.yml
@@ -12,4 +12,5 @@ services:
    - SOLR_HOST=solr
    - GLOBAL_legacy.transform.service.enabled=false
    - GLOBAL_local.transform.service.enabled=false
+   - APPLICATIONLOG_MAXDAYS=1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## 2021-04.1 (2021-04-16)
 ### Changed
-* [PR #66](https://github.com/xenit-eu/docker-alfresco/pull/66) DOCKER-376 Add support for limiting the number of application logs being kept. Changed WORKDIR
+* [PR #66](https://github.com/xenit-eu/docker-alfresco/pull/66) DOCKER-376 Changed WORKDIR
 	
 ## 2021-03.1 (2021-03-31)
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## 2021-04.1 (2021-04-16)
+### Changed
+* [PR #66](https://github.com/xenit-eu/docker-alfresco/pull/66) DOCKER-376 Add support for limiting the number of application logs being kept. Changed WORKDIR
+	
 ## 2021-03.1 (2021-03-31)
 ### Changed
 * [PR #65](https://github.com/xenit-eu/docker-alfresco/pull/65) DOCKER-373 Add build for alfresco 7.0.0 images; enhanced support for keystore env variables

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ Environment variables:
 | SSL_TRUSTSTORE_${alias}_PASSWORD     |                          | ssl-truststore.${alias}.password                             | kT9X6oe68t (for default alias `alfresco.ca`)                 |  |
 | GLOBAL_\<variable\>         | \<variable\>                      |                                                              |                                                              |  |
 | LOG4J_\<property-path\>     | N/A                               | N/A                                                          | N/A                                                          | Add the given property path and value to the alfresco log4j properties file. |
-| APPLICATIONLOG_MAXDAYS      | N/A                               | APPLICATIONLOG_MAXDAYS                                       | 5                                                            | Number of application log files to keep.|
 
 ## Support & Collaboration
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Environment variables:
 | SSL_TRUSTSTORE_${alias}_PASSWORD     |                          | ssl-truststore.${alias}.password                             | kT9X6oe68t (for default alias `alfresco.ca`)                 |  |
 | GLOBAL_\<variable\>         | \<variable\>                      |                                                              |                                                              |  |
 | LOG4J_\<property-path\>     | N/A                               | N/A                                                          | N/A                                                          | Add the given property path and value to the alfresco log4j properties file. |
-
+| APPLICATIONLOG_MAXDAYS      | N/A                               | APPLICATIONLOG_MAXDAYS                                       | 5                                                            | Number of application log files to keep.|
 
 ## Support & Collaboration
 

--- a/docker-init-script/src/main/java/eu/xenit/docker/alfresco/InitScriptMain.java
+++ b/docker-init-script/src/main/java/eu/xenit/docker/alfresco/InitScriptMain.java
@@ -204,9 +204,6 @@ public class InitScriptMain {
         javaOptions.add("-Dfile.encoding=UTF-8");
 
 
-        // logging
-        javaOptions.add("-DAPPLICATIONLOG_MAXDAYS=".concat(environment.containsKey("APPLICATIONLOG_MAXDAYS")?environment.get("APPLICATIONLOG_MAXDAYS"):"5"));
-
         // Special handling for alfresco 4 - set MaxPermSize
         if (alfrescoVersion.major == 4) {
             javaOptions.add("-XX:MaxPermSize=256m");

--- a/docker-init-script/src/main/java/eu/xenit/docker/alfresco/InitScriptMain.java
+++ b/docker-init-script/src/main/java/eu/xenit/docker/alfresco/InitScriptMain.java
@@ -204,6 +204,9 @@ public class InitScriptMain {
         javaOptions.add("-Dfile.encoding=UTF-8");
 
 
+        // logging
+        javaOptions.add("-DAPPLICATIONLOG_MAXDAYS=".concat(environment.containsKey("APPLICATIONLOG_MAXDAYS")?environment.get("APPLICATIONLOG_MAXDAYS"):"5"));
+
         // Special handling for alfresco 4 - set MaxPermSize
         if (alfrescoVersion.major == 4) {
             javaOptions.add("-XX:MaxPermSize=256m");

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton
@@ -37,7 +37,7 @@ RUN	mkdir -p /opt/alfresco && \
             --insert '$connector' --type attr --name maxHttpHeaderSize --value \$\{TOMCAT_MAX_HTTP_HEADER_SIZE\} \
             --insert '$connector' --type attr --name maxSavePostSize --value -1 \
         ${CATALINA_HOME}/conf/server.xml && \
-    #
+    # Configure tomcat-users
     xmlstarlet edit --inplace -N apache="http://tomcat.apache.org/xml" \
         --subnode "/apache:tomcat-users" --type elem --name user \
             --var user '$prev' \
@@ -50,9 +50,12 @@ RUN	mkdir -p /opt/alfresco && \
             --insert '$user' --type attr --name roles --value "repository" \
             --insert '$user' --type attr --name password --value "null" \
         ${CATALINA_HOME}/conf/tomcat-users.xml && \
-    #
-    #
-    # clean up
+    # Configure logging.properties
+    echo "1catalina.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
+    echo "2localhost.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
+    echo "3manager.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
+    echo "4host-manager.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
+    # Clean up
     apt-get --purge -y remove unzip && \
         apt-get --purge -y autoremove && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -76,7 +79,7 @@ RUN	chmod u+x /docker-entrypoint.d/90-init-alfresco.sh && \
 # named volumes
 VOLUME 	/opt/alfresco/alf_data ${CATALINA_HOME}/temp ${CATALINA_HOME}/logs
 
-WORKDIR /opt/alfresco
+WORKDIR /usr/local/tomcat/logs
 
 HEALTHCHECK --interval=10s --timeout=3s --retries=30 --start-period=20s CMD curl -f http://localhost:${TOMCAT_PORT}/alfresco/s/api/server || exit 1
 

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton
@@ -50,11 +50,6 @@ RUN	mkdir -p /opt/alfresco && \
             --insert '$user' --type attr --name roles --value "repository" \
             --insert '$user' --type attr --name password --value "null" \
         ${CATALINA_HOME}/conf/tomcat-users.xml && \
-    # Configure logging.properties
-    echo "1catalina.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
-    echo "2localhost.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
-    echo "3manager.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
-    echo "4host-manager.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
     # Clean up
     apt-get --purge -y remove unzip && \
         apt-get --purge -y autoremove && \

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
@@ -62,7 +62,7 @@ RUN	mkdir -p /opt/alfresco && \
             --insert '$connector' --type attr --name maxHttpHeaderSize --value \$\{TOMCAT_MAX_HTTP_HEADER_SIZE\} \
             --insert '$connector' --type attr --name maxSavePostSize --value -1 \
         ${CATALINA_HOME}/conf/server.xml && \
-    #
+    # Configure tomcat-users
     xmlstarlet edit --inplace -N apache="http://tomcat.apache.org/xml" \
         --subnode "/apache:tomcat-users" --type elem --name user \
             --var user '$prev' \
@@ -75,9 +75,12 @@ RUN	mkdir -p /opt/alfresco && \
             --insert '$user' --type attr --name roles --value "repository" \
             --insert '$user' --type attr --name password --value "null" \
         ${CATALINA_HOME}/conf/tomcat-users.xml && \
-    #
-    #
-    # clean up
+    # Configure logging.properties
+    echo "1catalina.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
+    echo "2localhost.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
+    echo "3manager.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
+    echo "4host-manager.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
+    # Clean up
     apt-get --purge -y remove unzip && \
         apt-get --purge -y autoremove && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -101,7 +104,7 @@ RUN	chmod u+x /docker-entrypoint.d/90-init-alfresco.sh && \
 # named volumes
 VOLUME 	/opt/alfresco/alf_data ${CATALINA_HOME}/temp ${CATALINA_HOME}/logs
 
-WORKDIR /opt/alfresco
+WORKDIR /usr/local/tomcat/logs
 
 HEALTHCHECK --interval=10s --timeout=3s --retries=30 --start-period=20s CMD curl -f http://localhost:${TOMCAT_PORT}/alfresco/s/api/server || exit 1
 

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton-pre6
@@ -75,11 +75,6 @@ RUN	mkdir -p /opt/alfresco && \
             --insert '$user' --type attr --name roles --value "repository" \
             --insert '$user' --type attr --name password --value "null" \
         ${CATALINA_HOME}/conf/tomcat-users.xml && \
-    # Configure logging.properties
-    echo "1catalina.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
-    echo "2localhost.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
-    echo "3manager.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
-    echo "4host-manager.org.apache.juli.AsyncFileHandler.maxDays = \${APPLICATIONLOG_MAXDAYS}" >>${CATALINA_HOME}/conf/logging.properties && \
     # Clean up
     apt-get --purge -y remove unzip && \
         apt-get --purge -y autoremove && \


### PR DESCRIPTION
Change WORKDIR, so that alfresco logs are being written in /usr/local/tomcat/logs.