### PR TITLE
Add workflow dispatch event to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: 'Continuous Integration'
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   continuousIntegration:

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 * [PR #74](https://github.com/xenit-eu/docker-alfresco/pull/74) DOCKER-406 Added Alfresco 7.2 to subprojects
+* [PR #76](https://github.com/xenit-eu/docker-alfresco/pull/74) Allow manual triggers of workflow
 
 ## 2022-02.03 (2022-02-03)
 


### PR DESCRIPTION
Allow users with write permissions to trigger builds manually.
See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
https://github.community/t/who-has-permission-to-workflow-dispatch/133981