### PR TITLE
DOCKER-446 Fixed issue where users can't be listed in the admin tools in Alfresco Share in a Community setup

### DIFF
--- a/1share-skeleton/6.1/local/share-config-custom.xml
+++ b/1share-skeleton/6.1/local/share-config-custom.xml
@@ -392,6 +392,17 @@
       </remote>
    </config>
 
+   <config evaluator="string-compare" condition="Users">
+      <users>
+         <!-- minimum length for username and password -->
+         <username-min-length>2</username-min-length>
+         <password-min-length>8</password-min-length>
+         <show-authorization-status>false</show-authorization-status>
+      </users>
+      <!-- This enables/disables the Add External Users Panel on the Add Users page. -->
+      <enable-external-users-panel>false</enable-external-users-panel>
+   </config>
+
    <!-- 
         Overriding endpoints to reference an Alfresco server with external SSO enabled
         NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky

--- a/1share-skeleton/6.2/local/share-config-custom.xml
+++ b/1share-skeleton/6.2/local/share-config-custom.xml
@@ -392,6 +392,17 @@
       </remote>
    </config>
 
+   <config evaluator="string-compare" condition="Users">
+      <users>
+         <!-- minimum length for username and password -->
+         <username-min-length>2</username-min-length>
+         <password-min-length>8</password-min-length>
+         <show-authorization-status>false</show-authorization-status>
+      </users>
+      <!-- This enables/disables the Add External Users Panel on the Add Users page. -->
+      <enable-external-users-panel>false</enable-external-users-panel>
+   </config>
+
    <!-- 
         Overriding endpoints to reference an Alfresco server with external SSO enabled
         NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky

--- a/1share-skeleton/7.0/local/share-config-custom.xml
+++ b/1share-skeleton/7.0/local/share-config-custom.xml
@@ -392,6 +392,17 @@
       </remote>
    </config>
 
+   <config evaluator="string-compare" condition="Users">
+      <users>
+         <!-- minimum length for username and password -->
+         <username-min-length>2</username-min-length>
+         <password-min-length>8</password-min-length>
+         <show-authorization-status>false</show-authorization-status>
+      </users>
+      <!-- This enables/disables the Add External Users Panel on the Add Users page. -->
+      <enable-external-users-panel>false</enable-external-users-panel>
+   </config>
+
    <!-- 
         Overriding endpoints to reference an Alfresco server with external SSO enabled
         NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky

--- a/1share-skeleton/7.1/local/share-config-custom.xml
+++ b/1share-skeleton/7.1/local/share-config-custom.xml
@@ -392,6 +392,17 @@
       </remote>
    </config>
 
+   <config evaluator="string-compare" condition="Users">
+      <users>
+         <!-- minimum length for username and password -->
+         <username-min-length>2</username-min-length>
+         <password-min-length>8</password-min-length>
+         <show-authorization-status>false</show-authorization-status>
+      </users>
+      <!-- This enables/disables the Add External Users Panel on the Add Users page. -->
+      <enable-external-users-panel>false</enable-external-users-panel>
+   </config>
+
    <!-- 
         Overriding endpoints to reference an Alfresco server with external SSO enabled
         NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky

--- a/1share-skeleton/7.2/local/share-config-custom.xml
+++ b/1share-skeleton/7.2/local/share-config-custom.xml
@@ -392,6 +392,17 @@
       </remote>
    </config>
 
+   <config evaluator="string-compare" condition="Users">
+      <users>
+         <!-- minimum length for username and password -->
+         <username-min-length>2</username-min-length>
+         <password-min-length>8</password-min-length>
+         <show-authorization-status>false</show-authorization-status>
+      </users>
+      <!-- This enables/disables the Add External Users Panel on the Add Users page. -->
+      <enable-external-users-panel>false</enable-external-users-panel>
+   </config>
+
    <!-- 
         Overriding endpoints to reference an Alfresco server with external SSO enabled
         NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky

--- a/1share-skeleton/7.3/local/share-config-custom.xml
+++ b/1share-skeleton/7.3/local/share-config-custom.xml
@@ -392,6 +392,17 @@
       </remote>
    </config>
 
+   <config evaluator="string-compare" condition="Users">
+      <users>
+         <!-- minimum length for username and password -->
+         <username-min-length>2</username-min-length>
+         <password-min-length>8</password-min-length>
+         <show-authorization-status>false</show-authorization-status>
+      </users>
+      <!-- This enables/disables the Add External Users Panel on the Add Users page. -->
+      <enable-external-users-panel>false</enable-external-users-panel>
+   </config>
+
    <!-- 
         Overriding endpoints to reference an Alfresco server with external SSO enabled
         NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky

--- a/1share-skeleton/7.4/local/share-config-custom.xml
+++ b/1share-skeleton/7.4/local/share-config-custom.xml
@@ -392,6 +392,17 @@
       </remote>
    </config>
 
+   <config evaluator="string-compare" condition="Users">
+      <users>
+         <!-- minimum length for username and password -->
+         <username-min-length>2</username-min-length>
+         <password-min-length>8</password-min-length>
+         <show-authorization-status>false</show-authorization-status>
+      </users>
+      <!-- This enables/disables the Add External Users Panel on the Add Users page. -->
+      <enable-external-users-panel>false</enable-external-users-panel>
+   </config>
+
    <!-- 
         Overriding endpoints to reference an Alfresco server with external SSO enabled
         NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky

--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 * [PR #201](https://github.com/xenit-eu/docker-alfresco/pull/201) XENOPS-1127 Bumped acs packageing version to the latest path version
+* [PR #205](https://github.com/xenit-eu/docker-alfresco/pull/205) DOCKER-446 Instead of webscript org/alfresco/enterprise/repository/person/people-enterprise.get, webscript org/alfresco/repository/person/people.get is now used by default to list the Alfresco users in the admin tools.
 
 ## 2022-02.03 (2022-02-03)
 


### PR DESCRIPTION
Instead of webscript `org/alfresco/enterprise/repository/person/people-enterprise.get`, webscript `org/alfresco/repository/person/people.get` is now used by default to list the Alfresco users in the admin tools.