### PR TITLE
DOCKER-464 Added json logging test

### DIFF
--- a/2repository/build.gradle
+++ b/2repository/build.gradle
@@ -38,10 +38,12 @@ subprojects {
 
     def parentProject = project(":1alfresco-skeleton:${project.alfresco.version.major}" + "." + "${project.alfresco.version.minor}")
     def parentImage = parentProject.getTasks().getByName('buildDockerImage')
+    def alfrescoRepository = calcRepository(project.alfresco.flavor,true)
+    def alfrescoTags = calcTags(project.alfresco.version)
 
     dockerBuild {
-        repositories = [calcRepository(project.alfresco.flavor,true)]
-        tags = calcTags(project.alfresco.version)
+        repositories = [alfrescoRepository]
+        tags = alfrescoTags
         alfresco {
             baseImage = parentImage.getImageId()
         }
@@ -79,7 +81,7 @@ subprojects {
             systemProperty 'alfresco.port.internal', '8080'
             systemProperty 'flavor', "${project.alfresco.flavor}"
             systemProperty 'version', "${project.alfresco.version.major}" + "." + "${project.alfresco.version.minor}"
-            systemProperty('alfresco_image_name', "${calcRepository(project.alfresco.flavor,true)}:${calcTags(project.alfresco.version).last()}")
+            systemProperty('alfresco_image_name', "${alfrescoRepository}:${alfrescoTags.last()}")
         }
     }
 

--- a/2repository/build.gradle
+++ b/2repository/build.gradle
@@ -27,6 +27,10 @@ subprojects {
         integrationTestImplementation group: 'io.rest-assured', name: 'rest-assured-common', version: '5.3.1'
         integrationTestImplementation group: 'junit', name: 'junit', version: '4.13.2'
         integrationTestImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+        integrationTestImplementation group: 'uk.org.webcompere', name: 'system-stubs-junit4', version: '2.1.8'
+        integrationTestImplementation group: 'com.github.docker-java', name: 'docker-java-core', version: '3.4.0'
+        integrationTestImplementation group: 'com.github.docker-java', name: 'docker-java-transport-httpclient5', version: '3.4.0'
+
 
         alfrescoSM(group: 'org.postgresql', name: 'postgresql', version: '42.6.0')
     }

--- a/2repository/build.gradle
+++ b/2repository/build.gradle
@@ -27,9 +27,6 @@ subprojects {
         integrationTestImplementation group: 'io.rest-assured', name: 'rest-assured-common', version: '5.3.1'
         integrationTestImplementation group: 'junit', name: 'junit', version: '4.13.2'
         integrationTestImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
-        integrationTestImplementation group: 'uk.org.webcompere', name: 'system-stubs-junit4', version: '2.1.8'
-        integrationTestImplementation group: 'com.github.docker-java', name: 'docker-java-core', version: '3.4.0'
-        integrationTestImplementation group: 'com.github.docker-java', name: 'docker-java-transport-httpclient5', version: '3.4.0'
         integrationTestImplementation group: 'org.testcontainers', name: 'testcontainers', version: '1.21.0'
 
         alfrescoSM(group: 'org.postgresql', name: 'postgresql', version: '42.6.0')

--- a/2repository/build.gradle
+++ b/2repository/build.gradle
@@ -30,7 +30,7 @@ subprojects {
         integrationTestImplementation group: 'uk.org.webcompere', name: 'system-stubs-junit4', version: '2.1.8'
         integrationTestImplementation group: 'com.github.docker-java', name: 'docker-java-core', version: '3.4.0'
         integrationTestImplementation group: 'com.github.docker-java', name: 'docker-java-transport-httpclient5', version: '3.4.0'
-
+        integrationTestImplementation group: 'org.testcontainers', name: 'testcontainers', version: '1.21.0'
 
         alfrescoSM(group: 'org.postgresql', name: 'postgresql', version: '42.6.0')
     }
@@ -82,6 +82,7 @@ subprojects {
             systemProperty 'alfresco.port.internal', '8080'
             systemProperty 'flavor', "${project.alfresco.flavor}"
             systemProperty 'version', "${project.alfresco.version.major}" + "." + "${project.alfresco.version.minor}"
+            systemProperty('alfresco_image_name', "${calcRepository(project.alfresco.flavor,true)}:${calcTags(project.alfresco.version).last()}")
         }
     }
 

--- a/2repository/src/integrationTest/java/eu/xenit/docker/alfresco/test/LoggingTests.java
+++ b/2repository/src/integrationTest/java/eu/xenit/docker/alfresco/test/LoggingTests.java
@@ -1,0 +1,108 @@
+package eu.xenit.docker.alfresco.test;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.core.DefaultDockerClientConfig;
+import com.github.dockerjava.core.DockerClientImpl;
+import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
+import com.github.dockerjava.transport.DockerHttpClient;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.org.webcompere.systemstubs.rules.EnvironmentVariablesRule;
+
+public class LoggingTests {
+
+    final Set<String> REQ_COMMON_LOGGING_FIELDS = Set.of("timestamp", "type");
+
+    final Set<String> REQ_APPLICATION_LOGGING_FIELDS = union(
+            Set.of("loggerName", "severity", "thread"), REQ_COMMON_LOGGING_FIELDS);
+
+    final Set<String> REQ_ACCESS_LOGGING_FIELDS = union(
+            Set.of("requestTime", "responseStatus", "requestMethod", "requestUri"),
+            REQ_COMMON_LOGGING_FIELDS);
+
+    private static <E> Set<E> union(Set<E> specificFields, Set<E> commonFields) {
+        Set<E> result = new HashSet<>(specificFields);
+        result.addAll(commonFields);
+        return result;
+    }
+    //TODO: Sql logs?
+
+    @Rule
+    public EnvironmentVariablesRule environmentVariablesRule = new EnvironmentVariablesRule();
+
+    private Container findContainerByName(String value, List<Container> containers) {
+        assert value != null && containers != null;
+        for (Container container : containers) {
+            for (String name : container.getNames()) {
+                if (name != null && name.contains(value)) {
+                    return container;
+                }
+            }
+        }
+        throw new AssertionError("No running docker container running for name: " + value);
+    }
+
+
+    private DockerClient createDockerClient() {
+        DefaultDockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
+        DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder().dockerHost(config.getDockerHost())
+                .sslConfig(config.getSSLConfig()).maxConnections(100).connectionTimeout(Duration.ofSeconds(30))
+                .responseTimeout(Duration.ofSeconds(45)).build();
+        return DockerClientImpl.getInstance(config, httpClient);
+    }
+    private void checkJsonLogs(String logs){
+        // TODO: json parsing?
+        Assert.fail();
+
+        String accessSample = logs.lines().filter(line -> line.contains("\"type\":\"access\"")).findFirst().orElseThrow(AssertionError::new);
+        for(String entry : REQ_ACCESS_LOGGING_FIELDS){
+            Assert.assertTrue("Access logs missing field: " + entry, accessSample.contains(entry));
+        }
+        String applicationSample = logs.lines().filter(line -> line.contains("\"type\":\"application\"")).findFirst().orElseThrow(AssertionError::new);
+        for(String entry : REQ_APPLICATION_LOGGING_FIELDS){
+            Assert.assertTrue("Application logs missing field: " + entry, applicationSample.contains(entry));
+        }
+    }
+
+    private static String getContainerLogs(DockerClient dockerClient, Container container)
+            throws InterruptedException {
+        StringBuilder logs = new StringBuilder();
+        ResultCallback.Adapter<Frame> callback = new ResultCallback.Adapter<>() {
+            public void onNext(Frame frame) {
+                logs.append(new String(frame.getPayload()));
+            }
+        };
+        // Might need to limit the amount of log lines retrieved if logs are too big using withTail(n)
+        dockerClient.logContainerCmd(container.getId()).withStdOut(true).withStdErr(true).exec(callback)
+                .awaitCompletion();
+        return logs.toString();
+    }
+
+    @Test
+    public void testJsonLogging() {
+        final String containerName = "alfresco";
+        try (DockerClient dockerClient = createDockerClient()) {
+            List<Container> containers = dockerClient.listContainersCmd().withStatusFilter(List.of("running")).exec();
+            Container container = findContainerByName(containerName, containers);
+            assert container != null;
+
+            String logs = getContainerLogs(dockerClient, container);
+            Assert.assertFalse(logs.isEmpty());
+            checkJsonLogs(logs);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        Assert.fail(); // TODO: with and without json logging
+    }
+
+
+}

--- a/2repository/src/integrationTest/java/eu/xenit/docker/alfresco/test/LoggingTests.java
+++ b/2repository/src/integrationTest/java/eu/xenit/docker/alfresco/test/LoggingTests.java
@@ -1,39 +1,23 @@
 package eu.xenit.docker.alfresco.test;
 
-import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.async.ResultCallback;
-import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.github.dockerjava.api.model.Container;
-import com.github.dockerjava.api.model.ContainerConfig;
-import com.github.dockerjava.api.model.Frame;
-import com.github.dockerjava.core.DefaultDockerClientConfig;
-import com.github.dockerjava.core.DockerClientImpl;
-import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
-import com.github.dockerjava.transport.DockerHttpClient;
-import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
 public class LoggingTests {
 
-    private static final Logger log = LoggerFactory.getLogger(LoggingTests.class);
+
+    public static final long WAIT_FOR_LOGS_DUR = Duration.ofSeconds(10).toMillis();
     final Set<String> REQ_COMMON_LOGGING_FIELDS = Set.of("timestamp", "type");
 
     final Set<String> REQ_APPLICATION_LOGGING_FIELDS = union(
             Set.of("loggerName", "severity", "thread", "shortMessage", "fullMessage"), REQ_COMMON_LOGGING_FIELDS);
 
-    final Set<String> REQ_ACCESS_LOGGING_FIELDS = union(
-            Set.of("requestTime", "responseStatus", "requestMethod", "requestUri"),
-            REQ_COMMON_LOGGING_FIELDS);
 
     private static <E> Set<E> union(Set<E> specificFields, Set<E> commonFields) {
         Set<E> result = new HashSet<>(specificFields);
@@ -41,117 +25,62 @@ public class LoggingTests {
         return result;
     }
 
-    private Container findContainerByName(String value, List<Container> containers) {
-        assert value != null && containers != null;
-        for (Container container : containers) {
-            for (String name : container.getNames()) {
-                if (name != null && name.contains(value)) {
-                    return container;
-                }
-            }
-        }
-        throw new AssertionError("No running docker container running for name: " + value);
-    }
-
-
-    private DockerClient createDockerClient() {
-        DefaultDockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
-        DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder().dockerHost(config.getDockerHost())
-                .sslConfig(config.getSSLConfig()).maxConnections(100).connectionTimeout(Duration.ofSeconds(30))
-                .responseTimeout(Duration.ofSeconds(45)).build();
-        return DockerClientImpl.getInstance(config, httpClient);
-    }
-
     private boolean isCorrectJsonLogs(String logs) {
-        // This fully relies on the logs containing one of each log type before this test runs.
-        String accessSample = logs.lines().filter(line -> line.contains("\"type\":\"access\"")).findFirst().orElse("");
         String applicationSample = logs.lines().filter(line -> line.contains("\"type\":\"application\"")).findFirst().orElse("");
-        return hasEntries(accessSample, REQ_ACCESS_LOGGING_FIELDS)
-                && hasEntries(applicationSample, REQ_APPLICATION_LOGGING_FIELDS);
+        return hasEntries(applicationSample, REQ_APPLICATION_LOGGING_FIELDS);
     }
 
-    private boolean hasEntries(String accessSample, Set<String> fields) {
-        assert accessSample != null;
+    private boolean hasEntries(String logSample, Set<String> fields) {
+        assert logSample != null;
         for (String entry : fields) {
-            if (!accessSample.contains(entry)) {
+            if (!logSample.contains(entry)) {
                 return false;
             }
         }
         return true;
     }
 
-    private static String getContainerLogs(DockerClient dockerClient, String containerId)
-            throws InterruptedException {
-        StringBuilder logs = new StringBuilder();
-        ResultCallback.Adapter<Frame> callback = new ResultCallback.Adapter<>() {
-            public void onNext(Frame frame) {
-                logs.append(new String(frame.getPayload()));
-            }
-        };
-        // Might need to limit the amount of log lines retrieved if logs are too big using withTail(n)
-        dockerClient.logContainerCmd(containerId).withStdOut(true).withStdErr(true).exec(callback)
-                .awaitCompletion();
-        return logs.toString();
-    }
-
-    @Test
-    public void testJsonLogging() throws IOException, InterruptedException {
-
-        final String containerName = "alfresco";
-        try (DockerClient dockerClient = createDockerClient()) {
-            List<Container> containers = dockerClient.listContainersCmd().withStatusFilter(List.of("running")).exec();
-            Container container = findContainerByName(containerName, containers);
-            assert container != null;
-            System.out.println(
-                    Arrays.toString(dockerClient.inspectContainerCmd(container.getId()).exec().getConfig().getEnv()));
-            String logs = getContainerLogs(dockerClient, container.getId());
-            Assert.assertFalse(logs.isEmpty());
-            Assert.assertTrue("Logs do not contain required fields or aren't json", isCorrectJsonLogs(logs));
+    private void alfrescoSetup(GenericContainer<?> alfContainer, boolean jsonLogging) {
+        alfContainer.withExposedPorts(8080);
+        alfContainer.withEnv(Map.of(
+                "ACCESS_LOGGING", "false",
+                "GLOBAL_legacy.transform.service.enabled", "false",
+                "GLOBAL_local.transform.service.enabled", "false"
+        ));
+        if (jsonLogging) {
+            alfContainer.withEnv("JSON_LOGGING", "true");
+        } else {
+            alfContainer.withEnv("JSON_LOGGING", "false");
         }
     }
 
     @Test
-    public void testNonJsonLogging() throws IOException, InterruptedException {
+    public void testNonJsonLogging() throws InterruptedException {
+        try (GenericContainer<?> alfresco = new GenericContainer<>(
+                DockerImageName.parse(System.getProperty("alfresco_image_name")))) {
+            alfrescoSetup(alfresco, false);
+            alfresco.start();
 
-        final String containerName = "alfresco";
-        try (DockerClient dockerClient = createDockerClient()) {
-            List<Container> containers = dockerClient.listContainersCmd().withStatusFilter(List.of("running")).exec();
-            Container container = findContainerByName(containerName, containers);
-            assert container != null;
-            String containerId = container.getId();
-            System.out.println(
-                    Arrays.toString(dockerClient.inspectContainerCmd(containerId).exec().getConfig().getEnv()));
-            InspectContainerResponse inspectResp = dockerClient.inspectContainerCmd(containerId).exec();
+            // Sleep to let the logs accumulate
+            Thread.sleep(WAIT_FOR_LOGS_DUR);
 
-            // Change envVars
-            ContainerConfig config = inspectResp.getConfig();
-            List<String> envVars = new ArrayList<>(
-                    config.getEnv() != null ? List.of(config.getEnv()) : Collections.emptyList());
-            envVars.removeIf(s -> s.startsWith("JSON_LOGGING="));
-            envVars.add("JSON_LOGGING=false");
+            String logs = alfresco.getLogs();
+            Assert.assertFalse("Logs should not be json", isCorrectJsonLogs(logs));
+        }
+    }
 
-            // Create new container
-            String newContainerId = dockerClient.createContainerCmd(config.getImage())
-                    .withName("no_json_container")
-                    .withEnv(envVars)
-                    .withCmd(config.getCmd())
-                    .withEntrypoint(config.getEntrypoint())
-                    .withHostConfig(inspectResp.getHostConfig())
-                    .exec()
-                    .getId();
+    @Test
+    public void testJsonLogging() throws InterruptedException {
+        try (GenericContainer<?> alfresco = new GenericContainer<>(
+                DockerImageName.parse(System.getProperty("alfresco_image_name")))) {
+            alfrescoSetup(alfresco, true);
+            alfresco.start();
 
-            // Start new container
-            dockerClient.startContainerCmd(newContainerId).exec();
-            Thread.sleep(10_000);
-            InspectContainerResponse newInspectResp = dockerClient.inspectContainerCmd(newContainerId).exec();
+            // Sleep to let the logs accumulate
+            Thread.sleep(WAIT_FOR_LOGS_DUR);
 
-            // Check logs of new container
-            String logs = getContainerLogs(dockerClient, newInspectResp.getId());
-            Assert.assertFalse(logs.isEmpty());
-            Assert.assertFalse("Logs should not be json logs", isCorrectJsonLogs(logs));
-            dockerClient.stopContainerCmd(newContainerId).withTimeout(5).exec();
-            dockerClient.removeContainerCmd(newContainerId).exec();
-            assert false;
+            String logs = alfresco.getLogs();
+            Assert.assertTrue("Logs do not contain required fields or aren't json", isCorrectJsonLogs(logs));
         }
     }
 }

--- a/2repository/src/integrationTest/java/eu/xenit/docker/alfresco/test/LoggingTests.java
+++ b/2repository/src/integrationTest/java/eu/xenit/docker/alfresco/test/LoggingTests.java
@@ -2,7 +2,9 @@ package eu.xenit.docker.alfresco.test;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ContainerConfig;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
@@ -10,14 +12,20 @@ import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LoggingTests {
 
+    private static final Logger log = LoggerFactory.getLogger(LoggingTests.class);
     final Set<String> REQ_COMMON_LOGGING_FIELDS = Set.of("timestamp", "type");
 
     final Set<String> REQ_APPLICATION_LOGGING_FIELDS = union(
@@ -72,7 +80,7 @@ public class LoggingTests {
         return true;
     }
 
-    private static String getContainerLogs(DockerClient dockerClient, Container container)
+    private static String getContainerLogs(DockerClient dockerClient, String containerId)
             throws InterruptedException {
         StringBuilder logs = new StringBuilder();
         ResultCallback.Adapter<Frame> callback = new ResultCallback.Adapter<>() {
@@ -81,23 +89,69 @@ public class LoggingTests {
             }
         };
         // Might need to limit the amount of log lines retrieved if logs are too big using withTail(n)
-        dockerClient.logContainerCmd(container.getId()).withStdOut(true).withStdErr(true).exec(callback)
+        dockerClient.logContainerCmd(containerId).withStdOut(true).withStdErr(true).exec(callback)
                 .awaitCompletion();
         return logs.toString();
     }
 
     @Test
     public void testJsonLogging() throws IOException, InterruptedException {
-        assert "true".equals(System.getenv().get("JSON_LOGGING"));
 
         final String containerName = "alfresco";
         try (DockerClient dockerClient = createDockerClient()) {
             List<Container> containers = dockerClient.listContainersCmd().withStatusFilter(List.of("running")).exec();
             Container container = findContainerByName(containerName, containers);
             assert container != null;
-            String logs = getContainerLogs(dockerClient, container);
+            System.out.println(
+                    Arrays.toString(dockerClient.inspectContainerCmd(container.getId()).exec().getConfig().getEnv()));
+            String logs = getContainerLogs(dockerClient, container.getId());
             Assert.assertFalse(logs.isEmpty());
             Assert.assertTrue("Logs do not contain required fields or aren't json", isCorrectJsonLogs(logs));
+        }
+    }
+
+    @Test
+    public void testNonJsonLogging() throws IOException, InterruptedException {
+
+        final String containerName = "alfresco";
+        try (DockerClient dockerClient = createDockerClient()) {
+            List<Container> containers = dockerClient.listContainersCmd().withStatusFilter(List.of("running")).exec();
+            Container container = findContainerByName(containerName, containers);
+            assert container != null;
+            String containerId = container.getId();
+            System.out.println(
+                    Arrays.toString(dockerClient.inspectContainerCmd(containerId).exec().getConfig().getEnv()));
+            InspectContainerResponse inspectResp = dockerClient.inspectContainerCmd(containerId).exec();
+
+            // Change envVars
+            ContainerConfig config = inspectResp.getConfig();
+            List<String> envVars = new ArrayList<>(
+                    config.getEnv() != null ? List.of(config.getEnv()) : Collections.emptyList());
+            envVars.removeIf(s -> s.startsWith("JSON_LOGGING="));
+            envVars.add("JSON_LOGGING=false");
+
+            // Create new container
+            String newContainerId = dockerClient.createContainerCmd(config.getImage())
+                    .withName("no_json_container")
+                    .withEnv(envVars)
+                    .withCmd(config.getCmd())
+                    .withEntrypoint(config.getEntrypoint())
+                    .withHostConfig(inspectResp.getHostConfig())
+                    .exec()
+                    .getId();
+
+            // Start new container
+            dockerClient.startContainerCmd(newContainerId).exec();
+            Thread.sleep(10_000);
+            InspectContainerResponse newInspectResp = dockerClient.inspectContainerCmd(newContainerId).exec();
+
+            // Check logs of new container
+            String logs = getContainerLogs(dockerClient, newInspectResp.getId());
+            Assert.assertFalse(logs.isEmpty());
+            Assert.assertFalse("Logs should not be json logs", isCorrectJsonLogs(logs));
+            dockerClient.stopContainerCmd(newContainerId).withTimeout(5).exec();
+            dockerClient.removeContainerCmd(newContainerId).exec();
+            assert false;
         }
     }
 }


### PR DESCRIPTION
Added integration tests that check if the logging in the alfresco container is JSON logging and contains the required fields.
Currently only checks the logs of type application. Access and SQL logs are not included in the test.